### PR TITLE
Update builder configuration for pack 0.4.0

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.3.0"
+version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -38,57 +38,57 @@ version = "0.3.0"
   id = "heroku/nodejs"
   uri = "buildpacks/nodejs"
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/ruby"
     version = "0.0.1"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
     version = "0.2"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/python"
     version = "v0.0.5.0.1"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
     version = "0.2"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/java"
     version = "0.13"
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/gradle"
     version = "v0.0.5.0.1"
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/php"
     version = "v0.0.5.0.1"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
     version = "0.2"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/go"
     version = "v0.0.5.0.1"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
     version = "0.2"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/nodejs"
     version = "v0.0.5.0.1"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.3.0"
+version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/nodejs"
@@ -22,16 +22,16 @@ version = "0.3.0"
   id = "heroku/java-function"
   uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.2.0/java-function-buildpack-v0.2.0.tgz"
 
-[[groups]]
+[[order]]
   # node functions
-  buildpacks = [
+  groups = [
     { id = "heroku/nodejs", version = "v0.0.5.0.1" },
     { id = "heroku/node-function", version = "0.4.2" },
   ]
 
-[[groups]]
+[[order]]
   # java functions
-  buildpacks = [
+  groups = [
     { id = "heroku/java", version = "0.13" },
     { id = "heroku/java-function", version = "0.2.0" },
   ]


### PR DESCRIPTION
This updates the `builder.toml`, and the builder base images to be compatible with pack 0.4.0 (which isn't released yet). but the resulting builder image should be compatible with pack 0.3.0 (the latest released version at this time).