### PR TITLE
Automatically publish heroku/pack, heroku/buildpacks, and heroku/functions-buildpacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,32 +154,32 @@ workflows:
             - create-build-image
       - test-getting-started-guide:
           language: go
-          name: Test Go
+          name: test-go
           requires:
             - create-service-builder
       - test-getting-started-guide:
           language: java
-          name: Test Java
+          name: test-java
           requires:
             - create-service-builder
       - test-getting-started-guide:
           language: node-js
-          name: Test Node.js
+          name: test-nodejs
           requires:
             - create-service-builder
       - test-getting-started-guide:
           language: php
-          name: Test PHP
+          name: test-php
           requires:
             - create-service-builder
       - test-getting-started-guide:
           language: Python
-          name: Test Python
+          name: test-python
           requires:
             - create-service-builder
       - test-getting-started-guide:
           language: Ruby
-          name: Test Ruby
+          name: test-ruby
           requires:
             - create-service-builder
       - publish-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - image: heroku/pack-runner:latest
     steps:
       - setup_remote_docker
-      - run: docker login -p $DOCKER_HUB_USER -p $DOCKER_HUB_PASS
+      - run: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASS
       - restore_cache:
           key: v1-docker-cache-<< parameters.local_image >>-{{ .Environment.CIRCLE_SHA1 }}
       - run: docker load < docker_cache_<< parameters.local_image >>/<< parameters.local_image >>.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
     docker:
       - image: heroku/pack-runner:latest
     steps:
+      - setup_remote_docker
       - restore_cache:
           key: v1-docker-cache-<< parameters.local_image >>-{{ .Environment.CIRCLE_SHA1 }}
       - run: docker load < docker_cache_<< parameters.local_image >>/<< parameters.local_image >>.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
             - create-service-builder
       - test-getting-started-guide:
           language: node-js
-          name: test-nodejs
+          name: test-node-js
           requires:
             - create-service-builder
       - test-getting-started-guide:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,27 @@ jobs:
       - run: docker load < docker_cache_run_base/pack-18.tar
       - run: docker load < docker_cache_buildpacks-18/buildpacks-18.tar
       - run: pack build pack-getting-started --path getting_started --builder buildpacks-18 --no-pull
+  publish-image:
+    parameters:
+      local_image:
+        description: "Name of the local image to publish"
+        type: string
+      remote_image:
+        description: "Name of the dockerhub image to publish"
+        type: string
+      remote_image_alias:
+        description: "Name of dockerhub image alias to publish"
+        type: string
+    docker:
+      - image: heroku/pack-runner:latest
+    steps:
+      - restore_cache:
+          key: v1-docker-cache-<< parameters.local_image >>-{{ .Environment.CIRCLE_SHA1 }}
+      - run: docker load < docker_cache_<< parameters.local_image >>/<< parameters.local_image >>.tar
+      - run: docker tag << parameters.local_image >> << parameters.remote_image >>
+      - run: docker tag << parameters.local_image >> << parameters.remote_image_alias >>
+      - run: docker push << parameters.remote_image >>
+      - run: docker push << parameters.remote_image_alias >>
 workflows:
   version: 2
   build-test-deploy:
@@ -161,3 +182,28 @@ workflows:
           name: Test Ruby
           requires:
             - create-service-builder
+      - publish-image:
+          name: publish-service-builder
+          local_image: buildpacks-18
+          remote_image: heroku/buildpacks:18
+          remote_image_alias: heroku/buildpacks:latest
+          requires:
+            - test-go
+            - test-java
+            - test-node-js
+            - test-php
+            - test-python
+            - test-ruby
+      - publish-image:
+          name: publish-functions-builder
+          local_image: functions-buildpacks-18
+          remote_image: heroku/functions-buildpacks:18
+          remote_image_alias: heroku/functions-buildpacks:latest
+          requires:
+            - create-functions-builder
+            - test-go
+            - test-java
+            - test-node-js
+            - test-php
+            - test-python
+            - test-ruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,17 @@ jobs:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/project/buildpacks
-  create-run-image:
+  create-image:
+    parameters:
+      dockerfile:
+        description: "Dockerfile to build"
+        type: string
+      image_file:
+        description: "Local image archive file name"
+        type: string
+      image_tag:
+        description: "Remote image tag name"
+        type: string
     docker:
       - image: heroku/pack-runner:latest
     steps:
@@ -29,29 +39,12 @@ jobs:
       - restore_cache:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
       - setup_remote_docker
-      - run: docker build -f Dockerfile.run -t heroku/pack:18 .
-      - run: mkdir docker_cache_run_base
-      - run: docker save heroku/pack:18 > docker_cache_run_base/pack-18.tar
+      - run: docker build -f << parameters.dockerfile >> -t << parameters.image_tag >> .
+      - run: docker save << parameters.image_tag >> > << parameters.image_file >>
       - save_cache:
-          key: v1-docker-cache-run-base-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-<< parameters.image_file >>-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - docker_cache_run_base
-  create-build-image:
-    docker:
-      - image: heroku/pack-runner:latest
-    steps:
-      - restore_cache:
-          key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
-      - setup_remote_docker
-      - run: docker build -f Dockerfile.build -t heroku/pack:18-build .
-      - run: mkdir docker_cache_build_base
-      - run: docker save heroku/pack:18-build > docker_cache_build_base/pack-18-build.tar
-      - save_cache:
-          key: v1-docker-cache-build-base-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - docker_cache_build_base
+            - << parameters.image_file >>
   create-pack-builder:
     parameters:
       buildertoml:
@@ -68,12 +61,12 @@ jobs:
       - restore_cache:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-docker-cache-build-base-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-pack-18-build-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-docker-cache-run-base-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-pack-18-{{ .Environment.CIRCLE_SHA1 }}
       - setup_remote_docker
-      - run: docker load < docker_cache_build_base/pack-18-build.tar
-      - run: docker load < docker_cache_run_base/pack-18.tar
+      - run: docker load < docker_cache_pack-18-build/pack-18-build.tar
+      - run: docker load < docker_cache_pack-18/pack-18.tar
       - run: pack create-builder << parameters.imagename >> --builder-config << parameters.buildertoml >> --no-pull
       - run: mkdir docker_cache_<< parameters.imagename >>
       - run: docker save << parameters.imagename >> > docker_cache_<< parameters.imagename >>/<< parameters.imagename >>.tar
@@ -92,13 +85,13 @@ jobs:
       - run: git clone https://github.com/heroku/<< parameters.language >>-getting-started.git getting_started
       - setup_remote_docker
       - restore_cache:
-          key: v1-docker-cache-build-base-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-pack-18-build-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-docker-cache-run-base-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-pack-18-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           key: v1-docker-cache-buildpacks-18-{{ .Environment.CIRCLE_SHA1 }}
-      - run: docker load < docker_cache_build_base/pack-18-build.tar
-      - run: docker load < docker_cache_run_base/pack-18.tar
+      - run: docker load < docker_cache_build_pack-18-build/pack-18-build.tar
+      - run: docker load < docker_cache_run_pack-18/pack-18.tar
       - run: docker load < docker_cache_buildpacks-18/buildpacks-18.tar
       - run: pack build pack-getting-started --path getting_started --builder buildpacks-18 --no-pull
   publish-image:
@@ -132,10 +125,18 @@ workflows:
       - install-buildpacks:
           requires:
             - clone
-      - create-run-image:
+      - create-image:
+          name: create-build-image
+          dockerfile: Dockerfile.build
+          image_tag: pack:18-build
+          image_file: pack-18-build.tar
           requires:
             - clone
-      - create-build-image:
+      - create-image:
+          name: create-run-image
+          dockerfile: Dockerfile.run
+          image_tag: pack:18
+          image_file: pack-18-run.tar
           requires:
             - clone
       - create-pack-builder:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,19 +87,19 @@ jobs:
       - run: git clone https://github.com/heroku/<< parameters.language >>-getting-started.git getting_started
       - setup_remote_docker
       - restore_cache:
-          key: v1-docker-cache-pack-18-build-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-build.tar
       - restore_cache:
-          key: v1-docker-cache-pack-18-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-run.tar
       - restore_cache:
-          key: v1-docker-cache-buildpacks-18-{{ .Environment.CIRCLE_SHA1 }}
-      - run: docker load < docker_cache_build_pack-18-build/pack-18-build.tar
-      - run: docker load < docker_cache_run_pack-18/pack-18.tar
-      - run: docker load < docker_cache_buildpacks-18/buildpacks-18.tar
-      - run: pack build pack-getting-started --path getting_started --builder buildpacks-18 --no-pull
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-buildpacks-18.tar
+      - run: docker load < pack-18-build.tar
+      - run: docker load < pack-18-run.tar
+      - run: docker load < buildpacks-18.tar
+      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
   publish-image:
     parameters:
       local_image:
-        description: "Name of the local image to publish"
+        description: "Name of the local image archive to publish"
         type: string
       remote_image:
         description: "Name of the dockerhub image to publish"
@@ -130,14 +130,14 @@ workflows:
       - create-image:
           name: create-build-image
           dockerfile: Dockerfile.build
-          image_tag: pack:18-build
+          image_tag: heroku/pack:18-build
           image_file: pack-18-build.tar
           requires:
             - clone
       - create-image:
           name: create-run-image
           dockerfile: Dockerfile.run
-          image_tag: pack:18
+          image_tag: heroku/pack:18
           image_file: pack-18-run.tar
           requires:
             - clone

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
       - image: heroku/pack-runner:latest
     steps:
       - setup_remote_docker
+      - run: docker login -p $DOCKER_HUB_USER -p $DOCKER_HUB_PASS
       - restore_cache:
           key: v1-docker-cache-<< parameters.local_image >>-{{ .Environment.CIRCLE_SHA1 }}
       - run: docker load < docker_cache_<< parameters.local_image >>/<< parameters.local_image >>.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,9 @@ workflows:
             - test-python
             - test-ruby
             - create-functions-builder
+          filters:
+            branches:
+              only: master
       - publish-image:
           name: publish-run-stack
           image_file: pack-18-run.tar
@@ -214,6 +217,9 @@ workflows:
             - test-python
             - test-ruby
             - create-functions-builder
+          filters:
+            branches:
+              only: master
       - publish-image:
           name: publish-service-builder
           image_file: buildpacks-18.tar
@@ -222,6 +228,9 @@ workflows:
           requires:
             - publish-build-stack
             - publish-run-stack
+          filters:
+            branches:
+              only: master
       - publish-image:
           name: publish-functions-builder
           image_file: functions-buildpacks-18.tar
@@ -230,3 +239,6 @@ workflows:
           requires:
             - publish-build-stack
             - publish-run-stack
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,16 +42,19 @@ jobs:
       - run: docker build -f << parameters.dockerfile >> -t << parameters.image_tag >> .
       - run: docker save << parameters.image_tag >> > << parameters.image_file >>
       - save_cache:
-          key: v1-docker-cache-<< parameters.image_file >>-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-<< parameters.image_file >>
           paths:
             - << parameters.image_file >>
   create-pack-builder:
     parameters:
-      buildertoml:
+      builder_toml:
         description: "Builder toml"
         type: string
-      imagename:
-        description: "Name of the image"
+      image_file:
+        description: "Local builder image archive file name"
+        type: string
+      image_tag:
+        description: "Remote builder image name"
         type: string
     docker:
       - image: heroku/pack-runner:latest
@@ -61,19 +64,18 @@ jobs:
       - restore_cache:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-docker-cache-pack-18-build-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-build.tar
       - restore_cache:
-          key: v1-docker-cache-pack-18-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-run.tar
       - setup_remote_docker
-      - run: docker load < docker_cache_pack-18-build/pack-18-build.tar
-      - run: docker load < docker_cache_pack-18/pack-18.tar
-      - run: pack create-builder << parameters.imagename >> --builder-config << parameters.buildertoml >> --no-pull
-      - run: mkdir docker_cache_<< parameters.imagename >>
-      - run: docker save << parameters.imagename >> > docker_cache_<< parameters.imagename >>/<< parameters.imagename >>.tar
+      - run: docker load < pack-18-build.tar
+      - run: docker load < pack-18-run.tar
+      - run: pack create-builder << parameters.image_tag >> --builder-config << parameters.builder_toml >> --no-pull
+      - run: docker save << parameters.image_tag >> > << parameters.image_file >>
       - save_cache:
-          key: v1-docker-cache-<< parameters.imagename >>-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-<< parameters.image_file >>
           paths:
-            - docker_cache_<< parameters.imagename >>
+            - << parameters.image_file >>
   test-getting-started-guide:
     parameters:
       language:
@@ -141,16 +143,18 @@ workflows:
             - clone
       - create-pack-builder:
           name: create-service-builder
-          imagename: buildpacks-18
-          buildertoml: builder.toml
+          image_tag: heroku/buildpacks:18
+          image_file: buildpacks-18.tar
+          builder_toml: builder.toml
           requires:
             - install-buildpacks
             - create-run-image
             - create-build-image
       - create-pack-builder:
           name: create-functions-builder
-          imagename: functions-buildpacks-18
-          buildertoml: functions-builder.toml
+          image_tag: heroku/functions-buildpacks:18
+          image_file: functions-buildpacks-18.tar
+          builder_toml: functions-builder.toml
           requires:
             - install-buildpacks
             - create-run-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
       - run: docker load < docker_cache_build_base/pack-18-build.tar
       - run: docker load < docker_cache_run_base/pack-18.tar
       - run: docker load < docker_cache_buildpacks-18/buildpacks-18.tar
-      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
+      - run: pack build pack-getting-started --path getting_started --builder buildpacks-18 --no-pull
 workflows:
   version: 2
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ workflows:
       - publish-image:
           name: publish-functions-builder
           image_file: functions-buildpacks-18
-          image_file: heroku/functions-buildpacks:18
+          image_tag: heroku/functions-buildpacks:18
           image_tag_alias: heroku/functions-buildpacks:latest
           requires:
             - publish-build-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,11 @@ jobs:
       - run: docker load < docker_cache_run_base/pack-18.tar
       - run: pack create-builder << parameters.imagename >> --builder-config << parameters.buildertoml >> --no-pull
       - run: mkdir docker_cache_builder
-      - run: docker save << parameters.imagename >> > docker_cache_builder/<< parameters.imagename >>.tar
+      - run: docker save << parameters.imagename >> > docker_cache_<< parameters.imagename >>/<< parameters.imagename >>.tar
       - save_cache:
-          key: v1-docker-cache-builder-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-<< parameters.imagename >>-{{ .Environment.CIRCLE_SHA1 }}
           paths:
-            - docker_cache_builder
+            - docker_cache_<< parameters.imagename >>
   test-getting-started-guide:
     parameters:
       language:
@@ -96,10 +96,10 @@ jobs:
       - restore_cache:
           key: v1-docker-cache-run-base-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: v1-docker-cache-builder-{{ .Environment.CIRCLE_SHA1 }}
+          key: v1-docker-cache-buildpacks-18-{{ .Environment.CIRCLE_SHA1 }}
       - run: docker load < docker_cache_build_base/pack-18-build.tar
       - run: docker load < docker_cache_run_base/pack-18.tar
-      - run: docker load < docker_cache_builder/buildpacks-18.tar
+      - run: docker load < docker_cache_buildpacks-18/buildpacks-18.tar
       - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,11 +116,11 @@ jobs:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-<< parameters.image_file >>
       - run: docker load < << parameters.image_file >>
       - run: docker push << parameters.image_tag >>
-      - run: docker tag << parameters.image_file >> << parameters.image_tag_alias >>
+      - run: docker tag << parameters.image_tag >> << parameters.image_tag_alias >>
       - run: docker push << parameters.image_tag_alias >>
 workflows:
   version: 2
-  build-test-deploy:
+  build-test-publish:
     jobs:
       - clone
       - install-buildpacks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,7 @@ workflows:
             - test-php
             - test-python
             - test-ruby
+            - create-functions-builder
       - publish-image:
           name: publish-run-stack
           image_file: pack-18-run.tar
@@ -212,6 +213,7 @@ workflows:
             - test-php
             - test-python
             - test-ruby
+            - create-functions-builder
       - publish-image:
           name: publish-service-builder
           image_file: buildpacks-18.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
             - publish-run-stack
       - publish-image:
           name: publish-functions-builder
-          image_file: functions-buildpacks-18
+          image_file: functions-buildpacks-18.tar
           image_tag: heroku/functions-buildpacks:18
           image_tag_alias: heroku/functions-buildpacks:latest
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,13 @@ jobs:
           paths:
             - docker_cache_build_base
   create-builder-image:
+    parameters:
+      buildertoml:
+        description: "Builder toml"
+        type: string
+      imagename:
+        description: "Name of the image"
+        type: string
     docker:
       - image: heroku/pack-runner:latest
     steps:
@@ -67,9 +74,9 @@ jobs:
       - setup_remote_docker
       - run: docker load < docker_cache_build_base/pack-18-build.tar
       - run: docker load < docker_cache_run_base/pack-18.tar
-      - run: pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
+      - run: pack create-builder << parameters.imagename >> --builder-config << parameters.buildertoml >> --no-pull
       - run: mkdir docker_cache_builder
-      - run: docker save heroku/buildpacks:18 > docker_cache_builder/buildpacks-18.tar
+      - run: docker save << parameters.imagename >> > docker_cache_builder/<< parameters.imagename >>.tar
       - save_cache:
           key: v1-docker-cache-builder-{{ .Environment.CIRCLE_SHA1 }}
           paths:
@@ -109,6 +116,17 @@ workflows:
           requires:
             - clone
       - create-builder-image:
+          name: create-pack-builder
+          imagename: buildpacks-18
+          buildertoml: builder.toml
+          requires:
+            - install-buildpacks
+            - docker-build-run-image
+            - docker-build-build-image
+      - create-builder-image:
+          name: create-pack-functions-builder
+          imagename: functions-buildpacks-18
+          buildertoml: functions-builder.toml
           requires:
             - install-buildpacks
             - docker-build-run-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           key: v1-docker-cache-build-base-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - docker_cache_build_base
-  create-builder-image:
+  create-pack-builder:
     parameters:
       buildertoml:
         description: "Builder toml"
@@ -115,16 +115,16 @@ workflows:
       - docker-build-build-image:
           requires:
             - clone
-      - create-builder-image:
-          name: create-pack-builder
+      - create-pack-builder:
+          name: create-pack-builder-buildpacks
           imagename: buildpacks-18
           buildertoml: builder.toml
           requires:
             - install-buildpacks
             - docker-build-run-image
             - docker-build-build-image
-      - create-builder-image:
-          name: create-pack-functions-builder
+      - create-pack-builder:
+          name: create-pack-builder-functions-buildpacks
           imagename: functions-buildpacks-18
           buildertoml: functions-builder.toml
           requires:
@@ -135,29 +135,29 @@ workflows:
           language: go
           name: Test Go
           requires:
-           - create-builder-image
+            - create-pack-builder-buildpacks
       - test-getting-started-guide:
           language: java
           name: Test Java
           requires:
-            - create-builder-image
+            - create-pack-builder-buildpacks
       - test-getting-started-guide:
           language: node-js
           name: Test Node.js
           requires:
-            - create-builder-image
+            - create-pack-builder-buildpacks
       - test-getting-started-guide:
           language: php
           name: Test PHP
           requires:
-            - create-builder-image
+            - create-pack-builder-buildpacks
       - test-getting-started-guide:
           language: Python
           name: Test Python
           requires:
-            - create-builder-image
+            - create-pack-builder-buildpacks
       - test-getting-started-guide:
           language: Ruby
           name: Test Ruby
           requires:
-            - create-builder-image
+            - create-pack-builder-buildpacks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,13 +98,13 @@ jobs:
       - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
   publish-image:
     parameters:
-      local_image:
+      image_file:
         description: "Name of the local image archive to publish"
         type: string
-      remote_image:
+      image_tag:
         description: "Name of the dockerhub image to publish"
         type: string
-      remote_image_alias:
+      image_tag_alias:
         description: "Name of dockerhub image alias to publish"
         type: string
     docker:
@@ -113,12 +113,11 @@ jobs:
       - setup_remote_docker
       - run: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASS
       - restore_cache:
-          key: v1-docker-cache-<< parameters.local_image >>-{{ .Environment.CIRCLE_SHA1 }}
-      - run: docker load < docker_cache_<< parameters.local_image >>/<< parameters.local_image >>.tar
-      - run: docker tag << parameters.local_image >> << parameters.remote_image >>
-      - run: docker tag << parameters.local_image >> << parameters.remote_image_alias >>
-      - run: docker push << parameters.remote_image >>
-      - run: docker push << parameters.remote_image_alias >>
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-<< parameters.image_file >>
+      - run: docker load < << parameters.image_file >>
+      - run: docker push << parameters.image_tag >>
+      - run: docker tag << parameters.image_file >> << parameters.image_tag_alias >>
+      - run: docker push << parameters.image_tag_alias >>
 workflows:
   version: 2
   build-test-deploy:
@@ -190,10 +189,10 @@ workflows:
           requires:
             - create-service-builder
       - publish-image:
-          name: publish-service-builder
-          local_image: buildpacks-18
-          remote_image: heroku/buildpacks:18
-          remote_image_alias: heroku/buildpacks:latest
+          name: publish-build-stack
+          image_file: pack-18-build.tar
+          image_tag: heroku/pack:18-build
+          image_tag_alias: heroku/pack:18-build
           requires:
             - test-go
             - test-java
@@ -202,15 +201,30 @@ workflows:
             - test-python
             - test-ruby
       - publish-image:
-          name: publish-functions-builder
-          local_image: functions-buildpacks-18
-          remote_image: heroku/functions-buildpacks:18
-          remote_image_alias: heroku/functions-buildpacks:latest
+          name: publish-run-stack
+          image_file: pack-18-run.tar
+          image_tag: heroku/pack:18
+          image_tag_alias: heroku/pack:18
           requires:
-            - create-functions-builder
             - test-go
             - test-java
             - test-node-js
             - test-php
             - test-python
             - test-ruby
+      - publish-image:
+          name: publish-service-builder
+          image_file: buildpacks-18.tar
+          image_tag: heroku/buildpacks:18
+          image_tag_alias: heroku/buildpacks:latest
+          requires:
+            - publish-build-stack
+            - publish-run-stack
+      - publish-image:
+          name: publish-functions-builder
+          image_file: functions-buildpacks-18
+          image_file: heroku/functions-buildpacks:18
+          image_tag_alias: heroku/functions-buildpacks:latest
+          requires:
+            - publish-build-stack
+            - publish-run-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/project/buildpacks
-  docker-build-run-image:
+  create-run-image:
     docker:
       - image: heroku/pack-runner:latest
     steps:
@@ -36,7 +36,7 @@ jobs:
           key: v1-docker-cache-run-base-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - docker_cache_run_base
-  docker-build-build-image:
+  create-build-image:
     docker:
       - image: heroku/pack-runner:latest
     steps:
@@ -75,7 +75,7 @@ jobs:
       - run: docker load < docker_cache_build_base/pack-18-build.tar
       - run: docker load < docker_cache_run_base/pack-18.tar
       - run: pack create-builder << parameters.imagename >> --builder-config << parameters.buildertoml >> --no-pull
-      - run: mkdir docker_cache_builder
+      - run: mkdir docker_cache_<< parameters.imagename >>
       - run: docker save << parameters.imagename >> > docker_cache_<< parameters.imagename >>/<< parameters.imagename >>.tar
       - save_cache:
           key: v1-docker-cache-<< parameters.imagename >>-{{ .Environment.CIRCLE_SHA1 }}
@@ -103,61 +103,61 @@ jobs:
       - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
 workflows:
   version: 2
-  test-languages:
+  build-test-deploy:
     jobs:
       - clone
       - install-buildpacks:
           requires:
             - clone
-      - docker-build-run-image:
+      - create-run-image:
           requires:
             - clone
-      - docker-build-build-image:
+      - create-build-image:
           requires:
             - clone
       - create-pack-builder:
-          name: create-pack-builder-buildpacks
+          name: create-service-builder
           imagename: buildpacks-18
           buildertoml: builder.toml
           requires:
             - install-buildpacks
-            - docker-build-run-image
-            - docker-build-build-image
+            - create-run-image
+            - create-build-image
       - create-pack-builder:
-          name: create-pack-builder-functions-buildpacks
+          name: create-functions-builder
           imagename: functions-buildpacks-18
           buildertoml: functions-builder.toml
           requires:
             - install-buildpacks
-            - docker-build-run-image
-            - docker-build-build-image
+            - create-run-image
+            - create-build-image
       - test-getting-started-guide:
           language: go
           name: Test Go
           requires:
-            - create-pack-builder-buildpacks
+            - create-service-builder
       - test-getting-started-guide:
           language: java
           name: Test Java
           requires:
-            - create-pack-builder-buildpacks
+            - create-service-builder
       - test-getting-started-guide:
           language: node-js
           name: Test Node.js
           requires:
-            - create-pack-builder-buildpacks
+            - create-service-builder
       - test-getting-started-guide:
           language: php
           name: Test PHP
           requires:
-            - create-pack-builder-buildpacks
+            - create-service-builder
       - test-getting-started-guide:
           language: Python
           name: Test Python
           requires:
-            - create-pack-builder-buildpacks
+            - create-service-builder
       - test-getting-started-guide:
           language: Ruby
           name: Test Ruby
           requires:
-            - create-pack-builder-buildpacks
+            - create-service-builder

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,17 @@ build: install-buildpacks deps
 	@docker build -f Dockerfile.build -t heroku/pack:18-build .
 	@docker build -f Dockerfile.run -t heroku/pack:18 .
 	@pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
-	@pack create-builder heroku/functions-buildpacks:nightly --builder-config functions-builder.toml --no-pull
+	@pack create-builder heroku/functions-buildpacks:18 --builder-config functions-builder.toml --no-pull
 	@docker tag heroku/buildpacks:18 heroku/buildpacks:latest
+	@docker tag heroku/functions-buildpacks:18 heroku/functions-buildpacks:latest
 
 publish: build
 	@docker push heroku/pack:18-build
 	@docker push heroku/pack:18
 	@docker push heroku/buildpacks:18
 	@docker push heroku/buildpacks:latest
-	@docker push heroku/functions-buildpacks:nightly
+	@docker push heroku/functions-buildpacks:18
+	@docker push heroku/functions-buildpacks:latest
 
 build-ci:
 	@docker build -f Dockerfile.ci -t heroku/pack-runner:latest .


### PR DESCRIPTION
This PR does a few things:

1. Creates a builder based on `functions-builder.toml` during testing. This file was previously untested.
2. Publishes `heroku/pack:18` and `heroku/pack:18-build` images automatically after successful testing.
3. Publishes `heroku/buildpacks:18` and `heroku/functions-buildpacks:18` images automatically after successful testing.
4. Drops use of `:nightly` tag, in favor of `:18` and `:latest` on `heroku/functions-buildpacks` for consistency with `heroku/buildpacks`.