### PR TITLE
Update to lifecycle 0.4.0

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -10,9 +10,9 @@ uri = "lifecycle.tgz"
   id = "heroku/java"
   uri = "https://github.com/heroku/java-buildpack/releases/download/v0.14/java-buildpack-v0.14.tgz"
 
-# [[buildpacks]]
-#   id = "heroku/ruby"
-#   uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
+ [[buildpacks]]
+   id = "heroku/ruby"
+   uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -38,15 +38,15 @@ uri = "lifecycle.tgz"
   id = "heroku/nodejs"
   uri = "buildpacks/nodejs"
 
-# [[order]]
-#   [[order.group]]
-#     id = "heroku/ruby"
-#     version = "0.0.1"
-#
-#   [[order.group]]
-#     id = "heroku/procfile"
-#     version = "0.3"
-#     optional = true
+[[order]]
+  [[order.group]]
+    id = "heroku/ruby"
+    version = "0.0.1"
+
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "0.3"
+    optional = true
 
 [[order]]
   [[order.group]]

--- a/builder.toml
+++ b/builder.toml
@@ -4,19 +4,19 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.3.0"
+uri = "lifecycle.tgz"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "https://github.com/heroku/java-buildpack/releases/download/v0.13/java-buildpack-v0.13.tgz"
+  uri = "https://github.com/heroku/java-buildpack/releases/download/v0.14/java-buildpack-v0.14.tgz"
 
-[[buildpacks]]
-  id = "heroku/ruby"
-  uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
+# [[buildpacks]]
+#   id = "heroku/ruby"
+#   uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "https://github.com/heroku/procfile-cnb/releases/download/v0.2/procfile-cnb-v0.2.tgz"
+  uri = "https://github.com/heroku/procfile-cnb/releases/download/v0.3/procfile-cnb-v0.3.tgz"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -38,57 +38,57 @@ version = "0.3.0"
   id = "heroku/nodejs"
   uri = "buildpacks/nodejs"
 
-[[groups]]
-  [[groups.buildpacks]]
-    id = "heroku/ruby"
-    version = "0.0.1"
+# [[order]]
+#   [[order.group]]
+#     id = "heroku/ruby"
+#     version = "0.0.1"
+#
+#   [[order.group]]
+#     id = "heroku/procfile"
+#     version = "0.3"
+#     optional = true
 
-  [[groups.buildpacks]]
-    id = "heroku/procfile"
-    version = "0.2"
-    optional = true
-
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/python"
-    version = "v0.0.5.0.1"
+    version = "v0.0.5.0.2"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "0.3"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/java"
-    version = "0.13"
+    version = "0.14"
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/gradle"
-    version = "v0.0.5.0.1"
+    version = "v0.0.5.0.2"
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/php"
-    version = "v0.0.5.0.1"
+    version = "v0.0.5.0.2"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "0.3"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/go"
-    version = "v0.0.5.0.1"
+    version = "v0.0.5.0.2"
 
-  [[groups.buildpacks]]
+  [[order.group]]
     id = "heroku/procfile"
-    version = "0.2"
+    version = "0.3"
     optional = true
 
-[[groups]]
-  [[groups.buildpacks]]
+[[order]]
+  [[order.group]]
     id = "heroku/nodejs"
-    version = "v0.0.5.0.1"
+    version = "v0.0.5.0.2"

--- a/builder.toml
+++ b/builder.toml
@@ -10,9 +10,9 @@ version = "0.4.0"
   id = "heroku/java"
   uri = "https://github.com/heroku/java-buildpack/releases/download/v0.14/java-buildpack-v0.14.tgz"
 
- [[buildpacks]]
-   id = "heroku/ruby"
-   uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
+[[buildpacks]]
+  id = "heroku/ruby"
+  uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
 
 [[buildpacks]]
   id = "heroku/procfile"

--- a/builder.toml
+++ b/builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-uri = "lifecycle.tgz"
+version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/buildpacks/install.sh
+++ b/buildpacks/install.sh
@@ -19,9 +19,11 @@ install_buildpack() {
 
   buildpack_toml="$(mktemp)"
   cat > "${buildpack_toml}" << TOML
+api = "0.2"
+
 [buildpack]
 id = "heroku/${buildpack}"
-version = "$cnb_shim_version.0.1"
+version = "$cnb_shim_version.0.2"
 name = "${buildpack_name}"
 
 [[stacks]]

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.3.0"
+version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/nodejs"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -12,7 +12,7 @@ version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/node-function"
-  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.3/node-function-buildpack-v0.4.3.tgz"
+  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.5.0/node-function-buildpack-v0.5.0.tgz"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -20,18 +20,24 @@ version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.2.1/java-function-buildpack-v0.2.1.tgz"
+  uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.3.0/java-function-buildpack-v0.3.0.tgz"
 
-[[groups]]
+[[order]]
   # node functions
-  buildpacks = [
-    { id = "heroku/nodejs", version = "v0.0.5.0.2" },
-    { id = "heroku/node-function", version = "0.4.3" },
-  ]
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "v0.0.5.0.2"
 
-[[groups]]
+  [[order.group]]
+    id = "heroku/node-function"
+    version = "0.5.0"
+
+[[order]]
   # java functions
-  buildpacks = [
-    { id = "heroku/java", version = "0.14" },
-    { id = "heroku/java-function", version = "0.2.1" },
-  ]
+  [[order.group]]
+    id = "heroku/java"
+    version = "0.14"
+
+  [[order.group]]
+    id = "heroku/java-function"
+    version = "0.3.0"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -20,7 +20,7 @@ version = "0.3.0"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.2.0/java-function-buildpack-v0.2.0.tgz"
+  uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.2.1/java-function-buildpack-v0.2.1.tgz"
 
 [[groups]]
   # node functions
@@ -32,6 +32,6 @@ version = "0.3.0"
 [[groups]]
   # java functions
   buildpacks = [
-    { id = "heroku/java", version = "0.13" },
-    { id = "heroku/java-function", version = "0.2.0" },
+    { id = "heroku/java", version = "0.14" },
+    { id = "heroku/java-function", version = "0.2.1" },
   ]

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.3.0"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "https://github.com/heroku/java-buildpack/releases/download/v0.13/java-buildpack-v0.13.tgz"
+  uri = "https://github.com/heroku/java-buildpack/releases/download/v0.14/java-buildpack-v0.14.tgz"
 
 [[buildpacks]]
   id = "heroku/java-function"
@@ -25,7 +25,7 @@ version = "0.3.0"
 [[groups]]
   # node functions
   buildpacks = [
-    { id = "heroku/nodejs", version = "v0.0.5.0.1" },
+    { id = "heroku/nodejs", version = "v0.0.5.0.2" },
     { id = "heroku/node-function", version = "0.4.2" },
   ]
 

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -12,7 +12,7 @@ version = "0.3.0"
 
 [[buildpacks]]
   id = "heroku/node-function"
-  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.2/node-function-buildpack-v0.4.2.tgz"
+  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.4.3/node-function-buildpack-v0.4.3.tgz"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -26,7 +26,7 @@ version = "0.3.0"
   # node functions
   buildpacks = [
     { id = "heroku/nodejs", version = "v0.0.5.0.2" },
-    { id = "heroku/node-function", version = "0.4.2" },
+    { id = "heroku/node-function", version = "0.4.3" },
   ]
 
 [[groups]]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/heroku/pack-images
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/buildpack/lifecycle v0.1.1-0.20190510142604-8612386b1cea
-	github.com/buildpack/pack v0.3.0 // indirect
+	github.com/buildpack/pack v0.4.1 // indirect
 	github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac // indirect
 	github.com/gotestyourself/gotestyourself v2.1.0+incompatible // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/buildpack/lifecycle v0.1.1-0.20190510142604-8612386b1cea h1:i6zTuXHb+
 github.com/buildpack/lifecycle v0.1.1-0.20190510142604-8612386b1cea/go.mod h1:y3A24c0w/CRkjJyVF6NX0cdugBCmBv7KZPGfV7y2O60=
 github.com/buildpack/pack v0.3.0 h1:B9+u6qWdFuVzCAQpiH2i5Cyu/v7EsIwcpkB1cD0jYEk=
 github.com/buildpack/pack v0.3.0/go.mod h1:1HrBd/hNAAuEX8LCdFo5oVj1SrlApH7+bC9ob3wOfSk=
+github.com/buildpack/pack v0.4.1 h1:+iZKxqMhqUDeIOuy6vfBe+o6R4mHjPycwFOMD5Z386g=
+github.com/buildpack/pack v0.4.1/go.mod h1:bUVHYGG2kJkTChe38h11GU7HwE/xzk1gEsRY11gFG2s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac h1:PThQaO4yCvJzJBUW1XoFQxLotWRhvX2fgljJX8yrhFI=
 github.com/containerd/continuity v0.0.0-20181027224239-bea7585dbfac/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -53,6 +55,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.0/go.mod h1:c8YoAQJ7+qIz9IQm9G72MJ4uDcrPeLjkrQ4yYIHdhyw=
+github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=


### PR DESCRIPTION
This upgrades to lifecycle `0.4.0` which introduces a breaking change as well uses the `api` key in `builder.toml`. This includes updates to the heroku buildpacks + shim to make sure it works.