### PR TITLE
Builder 0.5.0 and a fix

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -12,7 +12,7 @@ version = "0.5.0"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/cnb/heroku-buildpack-jvm-common-cnb.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/cnb/heroku-buildpack-jvm-common.tgz"
 
 [[buildpacks]]
   id = "heroku/ruby"

--- a/builder.toml
+++ b/builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.4.0"
+version = "0.5.0"
 
 [[buildpacks]]
   id = "heroku/java"


### PR DESCRIPTION
Upgrade lifecycle in `heroku/buildpacks:18` to 0.5.0, and fix the `heroku/jvm` URL