### PR TITLE
update nodejs-npm-buildpack to 0.1.2

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -44,7 +44,7 @@ version = "0.5.0"
 
 [[buildpacks]]
   id = "heroku/nodejs-npm-buildpack"
-  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.1.1/nodejs-npm-buildpack-v0.1.1.tgz"
+  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.1.2/nodejs-npm-buildpack-v0.1.2.tgz"
 
 [[order]]
   [[order.group]]
@@ -103,7 +103,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/nodejs-npm-buildpack"
-    version = "0.1.1"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -12,7 +12,7 @@ version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/nodejs-npm-buildpack"
-  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.1.1/nodejs-npm-buildpack-v0.1.1.tgz"
+  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.1.2/nodejs-npm-buildpack-v0.1.2.tgz"
 
 [[buildpacks]]
   id = "heroku/node-function"
@@ -34,7 +34,7 @@ version = "0.4.0"
 
   [[order.group]]
     id = "heroku/nodejs-npm-buildpack"
-    version = "0.1.1"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/node-function"


### PR DESCRIPTION
This supports build time env vars when using NPM, <https://github.com/heroku/nodejs-npm-buildpack/pull/14>