### PR TITLE
Fix the versions used for shims so it's more concise

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -59,7 +59,7 @@ version = "0.5.0"
 [[order]]
   [[order.group]]
     id = "heroku/python"
-    version = "v0.0.5.0.2"
+    version = "0.0.5.2"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -74,12 +74,12 @@ version = "0.5.0"
 [[order]]
   [[order.group]]
     id = "heroku/gradle"
-    version = "v0.0.5.0.2"
+    version = "0.0.5.2"
 
 [[order]]
   [[order.group]]
     id = "heroku/php"
-    version = "v0.0.5.0.2"
+    version = "0.0.5.2"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -89,7 +89,7 @@ version = "0.5.0"
 [[order]]
   [[order.group]]
     id = "heroku/go"
-    version = "v0.0.5.0.2"
+    version = "0.0.5.2"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/buildpacks/install.sh
+++ b/buildpacks/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 buildpacks_dir="$(cd $(dirname $0); pwd)" # absolute path
-cnb_shim_version="v0.0.5"
+cnb_shim_version="0.0.5"
 
 fetch_shim() {
   shim_dir="${1:?}"
-  curl -sfL "https://github.com/heroku/cnb-shim/releases/download/${cnb_shim_version}/cnb-shim-${cnb_shim_version}.tgz" | tar xz -C "${shim_dir}"
+  curl -sfL "https://github.com/heroku/cnb-shim/releases/download/v${cnb_shim_version}/cnb-shim-v${cnb_shim_version}.tgz" | tar xz -C "${shim_dir}"
 }
 
 install_buildpack() {
@@ -23,7 +23,7 @@ api = "0.2"
 
 [buildpack]
 id = "heroku/${buildpack}"
-version = "$cnb_shim_version.0.2"
+version = "${cnb_shim_version}.2"
 name = "${buildpack_name}"
 
 [[stacks]]


### PR DESCRIPTION
The shim versions were a little rediculous, for example:

```
$ pack build myimage --no-pull
===> DETECTING
[detector] heroku/php      v0.0.5.0.2
[detector] heroku/procfile 0.3
```

This PR changes the following:

* Remove the `v` prefix
* Shorten the actual buildpack version to just one number (this is largely superficial and meant to bust caches so there's no need to use major minor)

New look:

```
$ pack build myimage --no-pull
===> DETECTING
[detector] heroku/php      0.0.5.2
[detector] heroku/procfile 0.3
```