### PR TITLE
Support cnb bionic

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,7 +10,7 @@ RUN mkdir /app && \
 
 ENV CNB_USER_ID=${pack_uid}
 ENV CNB_GROUP_ID=${pack_gid}
-ENV STACK "io.buildpacks.stacks.bionic"
+ENV STACK "heroku-18"
 ENV CNB_STACK_ID "io.buildpacks.stacks.bionic"
 LABEL io.buildpacks.stack.id="io.buildpacks.stacks.bionic"
 USER heroku

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,7 +10,7 @@ RUN mkdir /app && \
 
 ENV CNB_USER_ID=${pack_uid}
 ENV CNB_GROUP_ID=${pack_gid}
-ENV STACK "heroku-18"
-ENV CNB_STACK_ID "heroku-18"
-LABEL io.buildpacks.stack.id="heroku-18"
+ENV STACK "io.buildpacks.stacks.bionic"
+ENV CNB_STACK_ID "io.buildpacks.stacks.bionic"
+LABEL io.buildpacks.stack.id="io.buildpacks.stacks.bionic"
 USER heroku

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -8,5 +8,5 @@ ARG pack_gid=1000
 RUN groupadd heroku --gid ${pack_gid} && \
   useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -d /workspace -m
 
-LABEL io.buildpacks.stack.id="heroku-18"
+LABEL io.buildpacks.stack.id="io.buildpacks.stacks.bionic"
 USER heroku

--- a/builder.toml
+++ b/builder.toml
@@ -1,5 +1,5 @@
 [stack]
-id = "heroku-18"
+id = "io.buildpacks.stacks.bionic"
 build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 

--- a/builder.toml
+++ b/builder.toml
@@ -20,7 +20,7 @@ version = "0.5.0"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "https://github.com/heroku/procfile-cnb/releases/download/v0.3/procfile-cnb-v0.3.tgz"
+  uri = "https://github.com/heroku/procfile-cnb/releases/download/v0.4/procfile-cnb-v0.4.tgz"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -53,7 +53,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.4"
     optional = true
 
 [[order]]
@@ -63,7 +63,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.4"
     optional = true
 
 [[order]]
@@ -77,7 +77,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.4"
     optional = true
 
 [[order]]
@@ -92,7 +92,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.4"
     optional = true
 
 [[order]]
@@ -102,7 +102,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.4"
     optional = true
 
 [[order]]
@@ -116,5 +116,5 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.4"
     optional = true

--- a/builder.toml
+++ b/builder.toml
@@ -8,14 +8,17 @@ version = "0.5.0"
 
 [[buildpacks]]
   id = "heroku/maven"
+  # TODO: release with https://github.com/heroku/heroku-buildpack-java/pull/128
   uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/cnb/heroku-buildpack-maven.tgz"
 
 [[buildpacks]]
   id = "heroku/jvm"
+  # TODO: release with https://github.com/heroku/heroku-buildpack-jvm-common/pull/118
   uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/cnb/heroku-buildpack-jvm-common.tgz"
 
 [[buildpacks]]
   id = "heroku/ruby"
+  # TODO: release with https://github.com/heroku/heroku-buildpack-ruby/pull/945
   uri = "https://github.com/heroku/heroku-buildpack-ruby/releases/download/cnb-alpha/ruby-buildpack-vCNB-alpha.tgz"
 
 [[buildpacks]]
@@ -39,12 +42,14 @@ version = "0.5.0"
   uri = "buildpacks/go"
 
 [[buildpacks]]
-  id = "heroku/nodejs-engine-buildpack"
-  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.3.0/nodejs-engine-buildpack-v0.3.0.tgz"
+  id = "heroku/nodejs-engine"
+  # TODO: release with https://github.com/heroku/nodejs-engine-buildpack/pull/31
+  uri = "/Users/jesse.brown/dev/nodejs-engine-buildpack/nodejs-engine-buildpack-v0.4.2.tgz"
 
 [[buildpacks]]
-  id = "heroku/nodejs-npm-buildpack"
-  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.1.2/nodejs-npm-buildpack-v0.1.2.tgz"
+  id = "heroku/nodejs-npm"
+  # TODO: release with https://github.com/heroku/nodejs-npm-buildpack/pull/18
+  uri = "/Users/jesse.brown/dev/nodejs-npm-buildpack/nodejs-npm-buildpack-v0.1.3.tgz"
 
 [[order]]
   [[order.group]]
@@ -107,12 +112,12 @@ version = "0.5.0"
 
 [[order]]
   [[order.group]]
-    id = "heroku/nodejs-engine-buildpack"
-    version = "0.3.0"
+    id = "heroku/nodejs-engine"
+    version = "0.4.2"
 
   [[order.group]]
-    id = "heroku/nodejs-npm-buildpack"
-    version = "0.1.2"
+    id = "heroku/nodejs-npm"
+    version = "0.1.3"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/buildpacks/install.sh
+++ b/buildpacks/install.sh
@@ -28,6 +28,9 @@ name = "${buildpack_name}"
 
 [[stacks]]
 id = "heroku-18"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
 TOML
 
   bash "${buildpack_dir}"/bin/install "${buildpack_toml}" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/${buildpack}.tgz"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -4,57 +4,79 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.4.0"
+version = "0.5.0"
 
 [[buildpacks]]
-  id = "heroku/nodejs-engine-buildpack"
-  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.3.0/nodejs-engine-buildpack-v0.3.0.tgz"
+  id = "heroku/nodejs-engine"
+  # TODO: release with https://github.com/heroku/nodejs-engine-buildpack/pull/31
+  uri = "/Users/jesse.brown/dev/nodejs-engine-buildpack/nodejs-engine-buildpack-v0.4.2.tgz"
 
 [[buildpacks]]
-  id = "heroku/nodejs-npm-buildpack"
-  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.1.2/nodejs-npm-buildpack-v0.1.2.tgz"
+  id = "heroku/nodejs-npm"
+  # TODO: release with https://github.com/heroku/nodejs-npm-buildpack/pull/18
+  uri = "/Users/jesse.brown/dev/nodejs-npm-buildpack/nodejs-npm-buildpack-v0.1.3.tgz"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v0.0.8/nodejs-sf-fx-buildpack-v0.0.8.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v0.0.9/nodejs-sf-fx-buildpack-v0.0.9.tgz"
 
 [[buildpacks]]
-  id = "heroku/node-function"
-  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.5.0/node-function-buildpack-v0.5.0.tgz"
+  id = "io.projectriff.node"
+  # TODO: Need vNext of riff, not a snapshot of master
+  uri = "https://storage.googleapis.com/projectriff/node-function-buildpack/io.projectriff.node-0.2.0-BUILD-SNAPSHOT-20200116161425-e2b48c6459db89db.tgz"
+
+[[buildpacks]]
+  id = "heroku/evergreen-node-system-function"
+  uri = "https://github.com/heroku/evergreen-node-system-function/releases/download/v0.0.1/evergreen-node-system-function-buildpack-v0.0.1.tgz"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "https://github.com/heroku/java-buildpack/releases/download/v0.14/java-buildpack-v0.14.tgz"
+  # TODO: release with https://github.com/heroku/java-buildpack/pull/9 and https://github.com/heroku/java-buildpack/pull/10
+  uri = "/Users/jesse.brown/dev/java-buildpack/java-buildpack-v0.15.tgz"
 
 [[buildpacks]]
-  id = "heroku/java-function"
-  uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.3.0/java-function-buildpack-v0.3.0.tgz"
+  id = "io.projectriff.java"
+  # TODO: Need vNext of riff, not a snapshot of master
+  uri = "https://storage.googleapis.com/projectriff/java-function-buildpack/io.projectriff.java-0.2.0-BUILD-SNAPSHOT-20200116165551-80d1532f85b1c3bb.tgz"
+
+[[buildpacks]]
+  id = "heroku/evergreen-java-system-function"
+  uri = "https://github.com/heroku/evergreen-java-system-function/releases/download/v0.0.1/evergreen-java-system-function-buildpack-v0.0.1.tgz"
+
 
 [[order]]
   # node functions
   [[order.group]]
-    id = "heroku/nodejs-engine-buildpack"
-    version = "0.3.0"
+    id = "heroku/nodejs-engine"
+    version = "0.4.2"
 
   [[order.group]]
-    id = "heroku/nodejs-npm-buildpack"
-    version = "0.1.2"
+    id = "heroku/nodejs-npm"
+    version = "0.1.3"
+
+  [[order.group]]
+    id = "io.projectriff.node"
+    version = "0.2.0-BUILD-SNAPSHOT"
+
+  [[order.group]]
+    id = "heroku/evergreen-node-system-function"
+    version = "0.0.1"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "0.0.8"
+    version = "0.0.9"
     optional = true
-
-  [[order.group]]
-    id = "heroku/node-function"
-    version = "0.5.0"
 
 [[order]]
   # java functions
   [[order.group]]
     id = "heroku/java"
-    version = "0.14"
+    version = "0.15"
 
   [[order.group]]
-    id = "heroku/java-function"
-    version = "0.3.0"
+    id = "io.projectriff.java"
+    version = "0.2.0-BUILD-SNAPSHOT"
+
+  [[order.group]]
+    id = "heroku/evergreen-java-system-function"
+    version = "0.0.1"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -1,5 +1,5 @@
 [stack]
-id = "heroku-18"
+id = "io.buildpacks.stacks.bionic"
 build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 


### PR DESCRIPTION
[This RFC](https://github.com/buildpacks/rfcs/pull/40) is working it's way through and it seems useful to be able to use Heroku buildpacks on `cloudfoundry/cnb:bionic`. This also aligns with how riff is compatible with [multiple stacks](https://github.com/projectriff/node-function-buildpack/blob/master/buildpack.toml#L22).

This updates the shim we use for our existing buildpacks to add the additional stack.

BLOCKED BY all the buildpack work to support the new label:

https://github.com/heroku/heroku-buildpack-java/pull/128
https://github.com/heroku/procfile-cnb/pull/2
https://github.com/heroku/heroku-buildpack-ruby/pull/945
https://github.com/heroku/heroku-buildpack-jvm-common/pull/118
https://github.com/heroku/java-function-buildpack/pull/11
https://github.com/heroku/java-buildpack/pull/9
https://github.com/heroku/node-function-buildpack/pull/36
https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pull/14
https://github.com/heroku/nodejs-npm-buildpack/pull/17
https://github.com/heroku/nodejs-engine-buildpack/pull/30

These are matching riff's language buildpack requirements
https://github.com/heroku/nodejs-engine-buildpack/pull/31
https://github.com/heroku/java-buildpack/pull/10

Version bumps to get a release
https://github.com/heroku/nodejs-npm-buildpack/pull/19
https://github.com/heroku/nodejs-engine-buildpack/pull/32