### PR TITLE
Get the build running again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,16 +174,6 @@ workflows:
           requires:
             - create-service-builder
       - test-getting-started-guide:
-          language: php
-          name: test-php
-          requires:
-            - create-service-builder
-      - test-getting-started-guide:
-          language: Python
-          name: test-python
-          requires:
-            - create-service-builder
-      - test-getting-started-guide:
           language: Ruby
           name: test-ruby
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,8 +201,6 @@ workflows:
             - test-go
             - test-java
             - test-node-js
-            - test-php
-            - test-python
             - test-ruby
             - create-functions-builder
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,8 +187,6 @@ workflows:
             - test-go
             - test-java
             - test-node-js
-            - test-php
-            - test-python
             - test-ruby
             - create-functions-builder
           filters:

--- a/builder.toml
+++ b/builder.toml
@@ -139,7 +139,7 @@ version = "0.5.0"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.3"
+    version = "0.5"
     optional = true
 
 [[order]]

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -56,7 +56,7 @@ version = "0.4.0"
 
   [[order.group]]
     id = "heroku/node-function"
-    version = "0.5.0"
+    version = "0.6.2"
 
 [[order]]
   # node functions

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -51,7 +51,7 @@ version = "0.4.0"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "0.0.10"
+    version = "0.0.11"
     optional = true
 
   [[order.group]]


### PR DESCRIPTION
This gets the CircleCI build running again. 

- The python and php classic buildpacks attempt to write to the buildpack's own directory. This is problematic in newer CNB versions, as that directory is read only. We're removing them from the build for now.
- Fixed a version number for the `nodejs-fn` buildpack
- Fixed a version number for the `procfile` buildpack
- Fixed a version number for the `node-function` buildpack