### PR TITLE
update nodejs-engine buildpack versions to 0.4.3

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -44,7 +44,7 @@ version = "0.5.0"
 
 [[buildpacks]]
   id = "heroku/nodejs-engine"
-  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.4.2/nodejs-engine-buildpack-v0.4.2.tgz"
+  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.4.3/nodejs-engine-buildpack-v0.4.3.tgz"
 
 [[buildpacks]]
   id = "heroku/nodejs-npm"
@@ -131,7 +131,7 @@ version = "0.5.0"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.4.2"
+    version = "0.4.3"
 
   [[order.group]]
     id = "heroku/nodejs-yarn"
@@ -145,7 +145,7 @@ version = "0.5.0"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.4.2"
+    version = "0.4.3"
 
   [[order.group]]
     id = "heroku/nodejs-npm"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -8,7 +8,7 @@ version = "0.4.0"
 
 [[buildpacks]]
   id = "heroku/nodejs-engine"
-  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.4.2/nodejs-engine-buildpack-v0.4.2.tgz"
+  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.4.3/nodejs-engine-buildpack-v0.4.3.tgz"
 
 [[buildpacks]]
   id = "heroku/nodejs-npm"
@@ -38,7 +38,7 @@ version = "0.4.0"
   # node functions
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.4.2"
+    version = "0.4.3"
 
   [[order.group]]
     id = "heroku/nodejs-npm"


### PR DESCRIPTION
Update to give builders up-to-date patch changes for Node buildpack.

Takes fix: https://github.com/heroku/nodejs-engine-buildpack/pull/36