### PR TITLE
Bump nodejs-sf-fx-buildback to 1.1.2

### DIFF
--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.1.0/nodejs-sf-fx-buildpack-v1.1.0.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.1.2/nodejs-sf-fx-buildpack-v1.1.2.tgz"
 
 [[buildpacks]]
   id = "heroku/node-function"
@@ -46,7 +46,7 @@ version = "0.6.1"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.1.0"
+    version = "1.1.2"
     optional = true
 
   [[order.group]]


### PR DESCRIPTION
- Support for Secrets.get(secret).get(key) and Secrets.getValue(secret,key)
- Reduced startup/secret-checking logging