### PR TITLE
Revert "upgrade to lifecycle 0.7.2. Some perf improvements to launcher."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export GO111MODULE=on
+export GOBIN=$(shell pwd)/.tools
 export PATH:=$(GOBIN):$(PATH)
 
 .EXPORT_ALL_VARIABLES:
@@ -7,7 +9,7 @@ SHELL=/bin/bash -o pipefail
 install-buildpacks:
 	@bash buildpacks/install.sh
 
-build: install-buildpacks
+build: install-buildpacks deps
 	@docker pull heroku/heroku:18-build
 	@docker build -f Dockerfile.build -t heroku/pack:18-build .
 	@docker build -f Dockerfile.run -t heroku/pack:18 .
@@ -31,4 +33,10 @@ build-ci:
 create-builder-fn-local:
 	@pack create-builder pack-images-local --builder-config functions-builder.toml --no-pull
 
-.PHONY: install-buildpacks build publish build-ci create-builder-fn-local
+deps:
+	@rm -rf .tools
+	@mkdir .tools
+	@go get -v github.com/buildpacks/pack@latest
+	@go install github.com/buildpacks/pack/cmd/pack
+
+.PHONY: install-buildpacks build publish build-ci create-builder-fn-local deps

--- a/builder.toml
+++ b/builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.7.2"
+version = "0.6.1"
 
 [[buildpacks]]
   id = "heroku/maven"
@@ -67,7 +67,7 @@ version = "0.7.2"
 [[order]]
   [[order.group]]
     id = "heroku/python"
-    version = "0.2.2"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -91,7 +91,7 @@ version = "0.7.2"
 [[order]]
   [[order.group]]
     id = "heroku/gradle"
-    version = "0.2.2"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -101,7 +101,7 @@ version = "0.7.2"
 [[order]]
   [[order.group]]
     id = "heroku/scala"
-    version = "0.2.2"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -111,7 +111,7 @@ version = "0.7.2"
 [[order]]
   [[order.group]]
     id = "heroku/php"
-    version = "0.2.2"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -121,7 +121,7 @@ version = "0.7.2"
 [[order]]
   [[order.group]]
     id = "heroku/go"
-    version = "0.2.2"
+    version = "0.1.2"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/buildpacks/install.sh
+++ b/buildpacks/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 buildpacks_dir="$(cd $(dirname $0); pwd)" # absolute path
-cnb_shim_version="0.2"
+cnb_shim_version="0.1"
 
 fetch_shim() {
   shim_dir="${1:?}"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.7.2"
+version = "0.6.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-engine"


### PR DESCRIPTION
Reverts heroku/pack-images#78

We need to update `pack 0.9.0' in [heroku/builder](https://github.com/heroku/builder) first as seen in buildpacks/pack#509.