### PR TITLE
Add a spring-boot builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ build:
 	@docker build -f Dockerfile.run -t heroku/pack:18 .
 	@pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
 	@pack create-builder heroku/functions-buildpacks:18 --builder-config functions-builder.toml --no-pull
+	@pack create-builder heroku/spring-boot-buildpacks:18 --builder-config spring-boot-builder.toml --no-pull
 	@docker tag heroku/buildpacks:18 heroku/buildpacks:latest
 	@docker tag heroku/functions-buildpacks:18 heroku/functions-buildpacks:latest
+	@docker tag heroku/spring-boot-buildpacks:18 heroku/spring-boot-buildpacks:latest
 
 publish: build
 	@docker push heroku/pack:18-build
@@ -18,6 +20,8 @@ publish: build
 	@docker push heroku/buildpacks:latest
 	@docker push heroku/functions-buildpacks:18
 	@docker push heroku/functions-buildpacks:latest
+	@docker push heroku/spring-boot-buildpacks:18
+	@docker push heroku/spring-boot-buildpacks:latest
 
 build-ci:
 	@docker build -f Dockerfile.ci -t heroku/pack-runner:latest .

--- a/spring-boot-builder.toml
+++ b/spring-boot-builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.7.4"
+version = "0.8.0"
 
 [[buildpacks]]
   id = "heroku/jvm"

--- a/spring-boot-builder.toml
+++ b/spring-boot-builder.toml
@@ -1,0 +1,22 @@
+[stack]
+id = "heroku-18"
+build-image = "heroku/pack:18-build"
+run-image = "heroku/pack:18"
+
+[lifecycle]
+version = "0.7.4"
+
+[[buildpacks]]
+  id = "heroku/jvm"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v104/heroku-jvm-cnb.tgz"
+
+[[buildpacks]]
+  id = "heroku/spring-boot"
+  uri = "https://github.com/jkutner/spring-boot-buildpack/releases/download/v0.1/heroku-spring-boot-buildpack.tgz"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/jvm"
+
+  [[order.group]]
+    id = "heroku/spring-boot"

--- a/spring-boot-builder.toml
+++ b/spring-boot-builder.toml
@@ -12,7 +12,7 @@ version = "0.7.4"
 
 [[buildpacks]]
   id = "heroku/spring-boot"
-  uri = "https://github.com/jkutner/spring-boot-buildpack/releases/download/v0.1/heroku-spring-boot-buildpack.tgz"
+  uri = "https://github.com/heroku-examples/spring-boot-buildpack/releases/download/v0.1/heroku-spring-boot-buildpack.tgz"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This builder works with the Spring-Boot plugins for [Gradle](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/gradle-plugin/reference/html/#build-image) and [Maven](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/maven-plugin/reference/html/#build-image).

## Example

```
$ ./gradlew bootBuildImage --builder heroku/spring-boot-buildpacks  
```