### PR TITLE
combine system and salesforce functions into single buildpack

### DIFF
--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -15,12 +15,8 @@ version = "0.6.1"
   uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.2.0/nodejs-npm-buildpack-v0.2.0.tgz"
 
 [[buildpacks]]
-  id = "heroku/evergreen-node-system-function"
-  uri = "https://github.com/heroku/evergreen-node-system-function/releases/download/v0.1.0/evergreen-node-system-function-v0.1.0.tgz"
-
-[[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.3.0/nodejs-sf-fx-buildpack-v1.3.0.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.4.1/nodejs-sf-fx-buildpack-v1.4.1.tgz"
 
 [[buildpacks]]
   id = "heroku/node-function"
@@ -49,13 +45,8 @@ version = "0.6.1"
     version = "0.2.0"
 
   [[order.group]]
-    id = "heroku/evergreen-node-system-function"
-    version = "0.1.0"
-
-  [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.3.0"
-    optional = true
+    version = "1.4.1"
 
   [[order.group]]
     id = "heroku/node-function"


### PR DESCRIPTION
The `heroku/evergreen-node-system-function` buildpack is no longer neccessary since it was merged with the Salesforce middleware function

https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pull/26

Because of this, the `salesforce/nodejs-fn` buildpack can no longer be `optional` 