### PR TITLE
replace forked heroku/node-function buildpack with riff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ workflows:
       - create-image:
           name: create-riff-build-image
           dockerfile: Dockerfile.build
-          image_tag: heroku/pack:18-build
+          image_tag: heroku/pack:18-riff-build
           image_file: pack-18-riff-build.tar
           target: riff-build
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - restore_cache:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
       - setup_remote_docker
-      - run: docker build -f << parameters.dockerfile >> --target << parameters.target >> -t << parameters.image_tag >> .
+      - run: docker build -f << parameters.dockerfile >> --target "<< parameters.target >>" -t << parameters.image_tag >> .
       - run: docker save << parameters.image_tag >> > << parameters.image_file >>
       - save_cache:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-<< parameters.image_file >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ workflows:
           name: create-riff-build-image
           dockerfile: Dockerfile.build
           image_tag: heroku/pack:18-build
-          image_file: pack-18-build.tar
+          image_file: pack-18-riff-build.tar
           target: riff-build
           requires:
             - clone

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ jobs:
       image_tag:
         description: "Remote image tag name"
         type: string
+      target:
+        description: "Docker build target"
+        type: string
+        default: ""
     docker:
       - image: heroku/pack-runner:latest
     steps:
@@ -28,7 +32,7 @@ jobs:
       - restore_cache:
           key: v1-buildpacks-{{ .Environment.CIRCLE_SHA1 }}
       - setup_remote_docker
-      - run: docker build -f << parameters.dockerfile >> -t << parameters.image_tag >> .
+      - run: docker build -f << parameters.dockerfile >> --target << parameters.target >> -t << parameters.image_tag >> .
       - run: docker save << parameters.image_tag >> > << parameters.image_file >>
       - save_cache:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-<< parameters.image_file >>
@@ -55,9 +59,12 @@ jobs:
       - restore_cache:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-build.tar
       - restore_cache:
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-riff-build.tar
+      - restore_cache:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-run.tar
       - setup_remote_docker
       - run: docker load < pack-18-build.tar
+      - run: docker load < pack-18-riff-build.tar
       - run: docker load < pack-18-run.tar
       - run: pack create-builder << parameters.image_tag >> --builder-config << parameters.builder_toml >> --no-pull
       - run: docker save << parameters.image_tag >> > << parameters.image_file >>
@@ -117,16 +124,17 @@ workflows:
           dockerfile: Dockerfile.build
           image_tag: heroku/pack:18-build
           image_file: pack-18-build.tar
+          target: build
           requires:
             - clone
       - create-image:
           name: create-riff-build-image
-          dockerfile: Dockerfile.riff.build
-          image_tag: heroku/pack:18-riff-build
-          image_file: pack-18-riff-build.tar
+          dockerfile: Dockerfile.build
+          image_tag: heroku/pack:18-build
+          image_file: pack-18-build.tar
+          target: riff-build
           requires:
             - clone
-            - create-build-image
       - create-image:
           name: create-run-image
           dockerfile: Dockerfile.run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,14 @@ workflows:
           requires:
             - clone
       - create-image:
+          name: create-riff-build-image
+          dockerfile: Dockerfile.riff.build
+          image_tag: heroku/pack:18-riff-build
+          image_file: pack-18-riff-build.tar
+          requires:
+            - clone
+            - create-build-image
+      - create-image:
           name: create-run-image
           dockerfile: Dockerfile.run
           image_tag: heroku/pack:18
@@ -141,7 +149,7 @@ workflows:
           builder_toml: functions-builder.toml
           requires:
             - create-run-image
-            - create-build-image
+            - create-riff-build-image
       - test-getting-started-guide:
           language: go
           name: test-go
@@ -189,6 +197,22 @@ workflows:
             branches:
               only: master
       - publish-image:
+          name: publish-build-riff-stack
+          image_file: pack-18-riff-build.tar
+          image_tag: heroku/pack:18-riff-build
+          image_tag_alias: heroku/pack:18-riff-build
+          requires:
+            - test-go
+            - test-java
+            - test-node-js
+            - test-ruby
+            - test-php
+            - test-python
+            - create-functions-builder
+          filters:
+            branches:
+              only: master
+      - publish-image:
           name: publish-run-stack
           image_file: pack-18-run.tar
           image_tag: heroku/pack:18
@@ -221,7 +245,7 @@ workflows:
           image_tag: heroku/functions-buildpacks:18
           image_tag_alias: heroku/functions-buildpacks:latest
           requires:
-            - publish-build-stack
+            - publish-build-riff-stack
             - publish-run-stack
           filters:
             branches:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM heroku/heroku:18-build
+FROM heroku/heroku:18-build AS build
 
 ARG pack_uid=1000
 ARG pack_gid=1000
@@ -13,4 +13,10 @@ ENV CNB_GROUP_ID=${pack_gid}
 ENV STACK "heroku-18"
 ENV CNB_STACK_ID "heroku-18"
 LABEL io.buildpacks.stack.id="heroku-18"
+USER heroku
+
+FROM build AS riff-build
+
+USER root
+RUN mkdir -p /platform/env && echo "1" > /platform/env/RIFF
 USER heroku

--- a/Dockerfile.riff.build
+++ b/Dockerfile.riff.build
@@ -1,5 +1,0 @@
-FROM heroku/pack:18-build
-
-USER root
-RUN mkdir -p /platform/env && echo "1" > /platform/env/RIFF
-USER heroku

--- a/Dockerfile.riff.build
+++ b/Dockerfile.riff.build
@@ -2,3 +2,4 @@ FROM heroku/pack:18-build
 
 USER root
 RUN mkdir -p /platform/env && echo "1" > /platform/env/RIFF
+USER heroku

--- a/Dockerfile.riff.build
+++ b/Dockerfile.riff.build
@@ -1,0 +1,4 @@
+FROM heroku/pack:18-build
+
+USER root
+RUN mkdir -p /platform/env && echo "1" > /platform/env/RIFF

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL=/bin/bash -o pipefail
 build:
 	@docker pull heroku/heroku:18-build
 	@docker build -f Dockerfile.build -t heroku/pack:18-build .
+	@docker build -f Dockerfile.riff.build -t heroku/pack:18-riff-build .
 	@docker build -f Dockerfile.run -t heroku/pack:18 .
 	@pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
 	@pack create-builder heroku/functions-buildpacks:18 --builder-config functions-builder.toml --no-pull
@@ -12,6 +13,7 @@ build:
 	@docker tag heroku/functions-buildpacks:18 heroku/functions-buildpacks:latest
 
 publish: build
+	@docker push heroku/pack:18-riff-build
 	@docker push heroku/pack:18-build
 	@docker push heroku/pack:18
 	@docker push heroku/buildpacks:18

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ SHELL=/bin/bash -o pipefail
 
 build:
 	@docker pull heroku/heroku:18-build
-	@docker build -f Dockerfile.build -t heroku/pack:18-build .
-	@docker build -f Dockerfile.riff.build -t heroku/pack:18-riff-build .
+	@docker build -f Dockerfile.build --target build -t heroku/pack:18-build .
+	@docker build -f Dockerfile.build --target riff-build -t heroku/pack:18-riff-build .
 	@docker build -f Dockerfile.run -t heroku/pack:18 .
 	@pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
 	@pack create-builder heroku/functions-buildpacks:18 --builder-config functions-builder.toml --no-pull

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.4.1/nodejs-sf-fx-buildpack-v1.4.1.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.0/nodejs-sf-fx-buildpack-v1.5.0.tgz"
 
 [[buildpacks]]
   id = "heroku/node-function"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.0/nodejs-sf-fx-buildpack-v1.5.0.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.1/nodejs-sf-fx-buildpack-v1.5.1.tgz"
 
 [[buildpacks]]
   id = "heroku/maven"
@@ -50,7 +50,7 @@ version = "0.6.1"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.5.0"
+    version = "1.5.1"
 
 [[order]]
   # java functions

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -19,10 +19,6 @@ version = "0.6.1"
   uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.0/nodejs-sf-fx-buildpack-v1.5.0.tgz"
 
 [[buildpacks]]
-  id = "heroku/node-function"
-  uri = "https://github.com/heroku/node-function-buildpack/releases/download/v0.7.0/node-function-buildpack-v0.7.0.tgz"
-
-[[buildpacks]]
   id = "heroku/maven"
   uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/cnb/heroku-buildpack-maven.tgz"
 

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -1,6 +1,6 @@
 [stack]
 id = "heroku-18"
-build-image = "heroku/pack:18-build"
+build-image = "heroku/pack:18-riff-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
@@ -34,6 +34,10 @@ version = "0.6.1"
   id = "heroku/java-function"
   uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.3.0/java-function-buildpack-v0.3.0.tgz"
 
+[[buildpacks]]
+  id = "io.projectriff.node"
+  uri = "https://storage.googleapis.com/projectriff/node-function-buildpack/io.projectriff.node-0.3.1-BUILD-SNAPSHOT-20200518152928-50737265933ec6fd.tgz"
+
 [[order]]
   # node functions
   [[order.group]]
@@ -45,12 +49,12 @@ version = "0.6.1"
     version = "0.2.0"
 
   [[order.group]]
-    id = "salesforce/nodejs-fn"
-    version = "1.4.1"
+    id = "io.projectriff.node"
+    version = "0.3.1-BUILD-SNAPSHOT"
 
   [[order.group]]
-    id = "heroku/node-function"
-    version = "0.7.0"
+    id = "salesforce/nodejs-fn"
+    version = "1.5.0"
 
 [[order]]
   # java functions


### PR DESCRIPTION
**NOTE: This PR has a dependency on https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/tag/v1.5.0

This PR is responsible for removing our dependency on our forked `heroku/node-function` buildpack/invoker, and instead will allow us to use the upstream version of riff.  

Additionally, short-term changes were made to satisfy the `RIFF=1` requirement in order for the `detect` phase to pass while building a function.  Having the ENV var stored in `/plaform` allows us to truly hide it from the user, and will make the removal process seamless.
  