### PR TITLE
chore: bump nodejs-sf-fx-buildpack to v1.4.3

### DIFF
--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.4.2/nodejs-sf-fx-buildpack-v1.4.2.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.4.3/nodejs-sf-fx-buildpack-v1.4.3.tgz"
 
 [[buildpacks]]
   id = "heroku/node-function"
@@ -46,7 +46,7 @@ version = "0.6.1"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.4.2"
+    version = "1.4.3"
 
   [[order.group]]
     id = "heroku/node-function"


### PR DESCRIPTION
This will allow the `DEBUG_PORT` to be used and automatically enabled when using `evergreen:function:start`