### PR TITLE
upgrade to lifecycle 0.7.5

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.7.4"
+version = "0.7.5"
 
 [[buildpacks]]
   id = "heroku/maven"


### PR DESCRIPTION
lifecycle `0.7.5` includes a fix for https://github.com/buildpacks/lifecycle/issues/290 which some users are experiencing when using our builder image to do a `pack build --publish` and seeing the following error message:

```
ERROR: failed to new app image: /root/.docker/config.json: stat /root/.docker/config.json: permission denied
```