### PR TITLE
Update to latest version of riff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,18 +59,11 @@ jobs:
       - restore_cache:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-build.tar
       - restore_cache:
-          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-riff-build.tar
-      - restore_cache:
           key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-run.tar
       - setup_remote_docker
-      - run: |
-          if [ -f "pack-18-build.tar" ]; then
-              docker load < pack-18-build.tar
-          fi
-      - run: |
-          if [ -f "pack-18-riff-build.tar" ]; then
-              docker load < pack-18-riff-build.tar
-          fi
+      - run: docker pull gcr.io/projectriff/streaming-http-adapter:0.1.3
+      - run: docker pull gcr.io/projectriff/node-function:0.6.1
+      - run: docker load < pack-18-build.tar
       - run: docker load < pack-18-run.tar
       - run: pack create-builder << parameters.image_tag >> --builder-config << parameters.builder_toml >> --no-pull
       - run: docker save << parameters.image_tag >> > << parameters.image_file >>
@@ -130,15 +123,6 @@ workflows:
           dockerfile: Dockerfile.build
           image_tag: heroku/pack:18-build
           image_file: pack-18-build.tar
-          target: build
-          requires:
-            - clone
-      - create-image:
-          name: create-riff-build-image
-          dockerfile: Dockerfile.build
-          image_tag: heroku/pack:18-riff-build
-          image_file: pack-18-riff-build.tar
-          target: riff-build
           requires:
             - clone
       - create-image:
@@ -163,7 +147,7 @@ workflows:
           builder_toml: functions-builder.toml
           requires:
             - create-run-image
-            - create-riff-build-image
+            - create-build-image
       - test-getting-started-guide:
           language: go
           name: test-go
@@ -211,22 +195,6 @@ workflows:
             branches:
               only: master
       - publish-image:
-          name: publish-build-riff-stack
-          image_file: pack-18-riff-build.tar
-          image_tag: heroku/pack:18-riff-build
-          image_tag_alias: heroku/pack:18-riff-build
-          requires:
-            - test-go
-            - test-java
-            - test-node-js
-            - test-ruby
-            - test-php
-            - test-python
-            - create-functions-builder
-          filters:
-            branches:
-              only: master
-      - publish-image:
           name: publish-run-stack
           image_file: pack-18-run.tar
           image_tag: heroku/pack:18
@@ -259,7 +227,7 @@ workflows:
           image_tag: heroku/functions-buildpacks:18
           image_tag_alias: heroku/functions-buildpacks:latest
           requires:
-            - publish-build-riff-stack
+            - publish-build-stack
             - publish-run-stack
           filters:
             branches:

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM heroku/heroku:18-build AS build
+FROM heroku/heroku:18-build
 
 ARG pack_uid=1000
 ARG pack_gid=1000
@@ -17,10 +17,4 @@ LABEL io.buildpacks.stack.id="heroku-18"
 ADD https://s3.amazonaws.com/heroku-fn-devex-staging/develop/latest/develop /cnb/lifecycle/develop
 RUN chmod +x /cnb/lifecycle/develop
 
-USER heroku
-
-FROM build AS riff-build
-
-USER root
-RUN mkdir -p /platform/env && echo "1" > /platform/env/RIFF
 USER heroku

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,9 +1,9 @@
 FROM circleci/golang:1.13.7
 RUN mkdir ~/.docker
 RUN echo '{}' > ~/.docker/config.json
-RUN wget https://github.com/buildpacks/pack/releases/download/v0.8.1/pack-v0.8.1-linux.tgz
-RUN tar xvf pack-v0.8.1-linux.tgz
-RUN rm pack-v0.8.1-linux.tgz
+RUN wget https://github.com/buildpacks/pack/releases/download/v0.11.1/pack-v0.11.1-linux.tgz
+RUN tar xvf pack-v0.11.1-linux.tgz
+RUN rm pack-v0.11.1-linux.tgz
 RUN mkdir -p $HOME/bin/
 RUN mv pack $HOME/bin/
 RUN pack --help

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ SHELL=/bin/bash -o pipefail
 
 build:
 	@docker pull heroku/heroku:18-build
-	@docker build -f Dockerfile.build --target build -t heroku/pack:18-build .
-	@docker build -f Dockerfile.build --target riff-build -t heroku/pack:18-riff-build .
+	@docker build -f Dockerfile.build -t heroku/pack:18-build .
 	@docker build -f Dockerfile.run -t heroku/pack:18 .
 	@pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
 	@pack create-builder heroku/functions-buildpacks:18 --builder-config functions-builder.toml --no-pull
@@ -13,7 +12,6 @@ build:
 	@docker tag heroku/functions-buildpacks:18 heroku/functions-buildpacks:latest
 
 publish: build
-	@docker push heroku/pack:18-riff-build
 	@docker push heroku/pack:18-build
 	@docker push heroku/pack:18
 	@docker push heroku/buildpacks:18

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.2"
 
 [buildpack]
 id = "evergreen/fn"
-version = "0.1"
+version = "0.2"
 name = "Evergreen Function"
 
 [[order]]
@@ -15,9 +15,13 @@ name = "Evergreen Function"
     version = "0.2.0"
 
   [[order.group]]
-    id = "io.projectriff.node"
-    version = "0.3.1-BUILD-SNAPSHOT"
+    id = "projectriff/streaming-http-adapter"
+    version = "0.1.3"
+
+  [[order.group]]
+    id = "projectriff/node-function"
+    version = "0.6.1"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.5.2"
+    version = "1.5.3"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -1,6 +1,6 @@
 [stack]
 id = "heroku-18"
-build-image = "heroku/pack:18-riff-build"
+build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.2/nodejs-sf-fx-buildpack-v1.5.2.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.3/nodejs-sf-fx-buildpack-v1.5.3.tgz"
 
 [[buildpacks]]
   id = "heroku/maven"
@@ -31,8 +31,12 @@ version = "0.6.1"
   uri = "https://github.com/heroku/java-function-buildpack/releases/download/v0.3.0/java-function-buildpack-v0.3.0.tgz"
 
 [[buildpacks]]
-  id = "io.projectriff.node"
-  uri = "https://storage.googleapis.com/projectriff/node-function-buildpack/io.projectriff.node-0.3.1-BUILD-SNAPSHOT-20200518152928-50737265933ec6fd.tgz"
+  id = "projectriff/streaming-http-adapter"
+  image = "gcr.io/projectriff/streaming-http-adapter:0.1.3"
+
+[[buildpacks]]
+  id = "projectriff/node-function"
+  image = "gcr.io/projectriff/node-function:0.6.1"
 
 [[buildpacks]]
   id = "evergreen/fn"


### PR DESCRIPTION
Riff is now split into multiple buildpacks instead of including the streaming adapter as a dependency. Riff also no longer requires `RIFF=1` to pass detection. Requiring the invoker buildpack is enough. The new requirement is in the sf-fx buildpack version bump.

I also updated pack builder image to ensure CI supports building the builder with the grc image references.

Example function being built with the updated builder. You can see the streaming adapter version is updated and that we have the new adapter buildpack.

All this is for [this work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008PK6fIAG/view) to support errors returned as JSON in failure states. Contributed that patch [here](https://github.com/projectriff/streaming-http-adapter/pull/56) and it was cut in the release referenced in this PR.

```
» sfdx evergreen:function:build idkman --no-pull --builder heroku/functions-buildpacks -v
BUILD SETTINGS
-------------------------------------------------------
Builder: heroku/functions-buildpacks
Network:
Buildpacks: []
Clear Cache: false
ENV file:
Image: idkman
No Pull: true
Publish: false
Run Image: heroku/pack:18
Working Directory: .
-------------------------------------------------------
Starting build
Using provided run-image heroku/pack:18
Using build cache volume pack-cache-1925d1a2e67c.build
===> DETECTING
[detector] ======== Output: salesforce/nodejs-fn@1.5.3 ========
[detector] detected package.json
[detector] ======== Results ========
[detector] pass: heroku/nodejs-engine@0.4.3
[detector] pass: heroku/nodejs-npm@0.2.0
[detector] pass: projectriff/streaming-http-adapter@0.1.3
[detector] pass: projectriff/node-function@0.6.1
[detector] pass: salesforce/nodejs-fn@1.5.3
[detector] Resolving plan... (try #1)
[detector] heroku/nodejs-engine               0.4.3
[detector] heroku/nodejs-npm                  0.2.0
[detector] projectriff/streaming-http-adapter 0.1.3
[detector] projectriff/node-function          0.6.1
[detector] salesforce/nodejs-fn               1.5.3
===> ANALYZING
[analyzer] Analyzing image "30b1f3cc61135058c5c76b855c27241f4eb0c18d5b6a4b6c2e574ffc70c19f18"
[analyzer] Restoring metadata for "heroku/nodejs-engine:nodejs" from app image
[analyzer] Writing layer metadata for "heroku/nodejs-engine:nodejs"
[analyzer] Not restoring "heroku/nodejs-engine:nodejs" from cache, marked as launch=true
[analyzer] Restoring metadata for "heroku/nodejs-engine:toolbox" from cache
[analyzer] Writing layer metadata for "heroku/nodejs-engine:toolbox"
[analyzer] Restoring metadata for "heroku/nodejs-npm:node_modules" from cache
[analyzer] Writing layer metadata for "heroku/nodejs-npm:node_modules"
[analyzer] Restoring metadata for "projectriff/streaming-http-adapter:adapter" from app image
[analyzer] Writing layer metadata for "projectriff/streaming-http-adapter:adapter"
[analyzer] Restoring metadata for "projectriff/node-function:function" from app image
[analyzer] Writing layer metadata for "projectriff/node-function:function"
[analyzer] Restoring metadata for "projectriff/node-function:invoker" from app image
[analyzer] Writing layer metadata for "projectriff/node-function:invoker"
[analyzer] Restoring metadata for "salesforce/nodejs-fn:middleware" from app image
[analyzer] Writing layer metadata for "salesforce/nodejs-fn:middleware"
[analyzer] Restoring metadata for "salesforce/nodejs-fn:dist" from cache
[analyzer] Writing layer metadata for "salesforce/nodejs-fn:dist"
[analyzer] Restoring metadata for "salesforce/nodejs-fn:node_modules" from cache
[analyzer] Writing layer metadata for "salesforce/nodejs-fn:node_modules"
===> RESTORING
[restorer] Restoring data for "heroku/nodejs-engine:nodejs" from cache
[restorer] Restoring data for "heroku/nodejs-engine:toolbox" from cache
[restorer] Restoring data for "heroku/nodejs-npm:node_modules" from cache
[restorer] Retrieving data for "sha256:328f283f7e972466b23ac2cc19bb9a4dae9937b66447e4b03da4f24b59e52972"
[restorer] Restoring data for "salesforce/nodejs-fn:dist" from cache
[restorer] Restoring data for "salesforce/nodejs-fn:node_modules" from cache
[restorer] Retrieving data for "sha256:b969775ed39727a2bc56125027f04c5b8cfc3160902debcdf5230b55b9b3162c"
[restorer] Retrieving data for "sha256:dc27a0a7afb5e54876ae28ddd037c0b274ebf5bc33dbd6a867180ad0b347198b"
[restorer] Retrieving data for "sha256:4398e624fd8a263967952563328c27fb18b34594aae783d6c4fc28177623b894"
[restorer] Retrieving data for "sha256:2bfc9a30039edb1b86083e38e36ed0c455efbc48057c860d297ce01abee332c9"
===> BUILDING
[builder] ---> Node.js Buildpack
[builder] ---> Installing toolbox
[builder] ---> Getting Node version
[builder] ---> Resolving Node version
[builder] ---> Reusing Node v12.18.0
[builder] ---> Parsing package.json
[builder] ---> Using npm v6.14.4 from Node
[builder] ---> Reusing node modules
[builder]
[builder] riff Streaming HTTP Adapter Buildpack 0.1.3
[builder]   https://github.com/projectriff/streaming-http-adapter-buildpack
[builder]   riff Streaming HTTP Adapter 0.5.4: Reusing cached layer
[builder]
[builder] riff NodeJS Function Buildpack 0.6.1
[builder]   https://github.com/projectriff/node-function-buildpack
[builder]   Build Configuration:
[builder]     $RIFF             whether this is a riff function without a riff.toml file
[builder]     $RIFF_ARTIFACT    the artifact to invoke
[builder]   riff NodeJS Invoker 0.3.0: Reusing cached layer
[builder]   NodeJS: Reusing cached layer
[builder]   Process types:
[builder]     function:      streaming-http-adapter node /layers/projectriff_node-function/invoker/server.js
[builder]     node-function: streaming-http-adapter node /layers/projectriff_node-function/invoker/server.js
[builder]     web:           streaming-http-adapter node /layers/projectriff_node-function/invoker/server.js
[builder] BP_DIR:  /cnb/buildpacks/salesforce_nodejs-fn/1.5.3
[builder] LAYERS_DIR:  /layers/salesforce_nodejs-fn
[builder] MW_LAYER:  /layers/salesforce_nodejs-fn/middleware
[builder] using previous node_modules and dist artifacts from cache
===> EXPORTING
[exporter] Reusing layers from image with id '30b1f3cc61135058c5c76b855c27241f4eb0c18d5b6a4b6c2e574ffc70c19f18'
[exporter] Writing tarball for layer "launcher"
[exporter] Reusing layer 'launcher'
[exporter] Layer 'launcher' SHA: sha256:a9e8a84f59d684926f7dbc105ffc7fc7a39eb87fa25c41526f2fef6ec8220737
[exporter] Writing tarball for layer "heroku/nodejs-engine:nodejs"
[exporter] Reusing layer 'heroku/nodejs-engine:nodejs'
[exporter] Layer 'heroku/nodejs-engine:nodejs' SHA: sha256:328f283f7e972466b23ac2cc19bb9a4dae9937b66447e4b03da4f24b59e52972
[exporter] Reusing layer 'projectriff/streaming-http-adapter:adapter'
[exporter] Layer 'projectriff/streaming-http-adapter:adapter' SHA: sha256:00d59ae648061904ff16012a3b635ea4c01b8855da4ed7359de58d351475aa17
[exporter] Reusing layer 'projectriff/node-function:function'
[exporter] Layer 'projectriff/node-function:function' SHA: sha256:4be94a84745e183cd8b457b34a16a786004584da3c13f55596cc6ea99e690bac
[exporter] Reusing layer 'projectriff/node-function:invoker'
[exporter] Layer 'projectriff/node-function:invoker' SHA: sha256:f56b785f9565de73021e3357bc249a5c74f39f8a3955567312063d9e90e1b945
[exporter] Writing tarball for layer "salesforce/nodejs-fn:middleware"
[exporter] Reusing layer 'salesforce/nodejs-fn:middleware'
[exporter] Layer 'salesforce/nodejs-fn:middleware' SHA: sha256:7f8d1c914a10337f31e373b7023b5ed38f988b70218fc9b6458808a99ef545cb
[exporter] Layer 'app' SHA: sha256:9593bccca99b9c71b07923b4382bc9576d8ef44c1a377116fa4b592240d4abe4
[exporter] Reusing 1/1 app layer(s)
[exporter] Writing tarball for layer "config"
[exporter] Reusing layer 'config'
[exporter] Layer 'config' SHA: sha256:a158eddd1fdedfea869a491d65b2b85447f636c0cc1d2cbff72f0bec2c956279
[exporter] *** Images (b1d1366a5595):
[exporter]       index.docker.io/library/idkman:latest
[exporter]
[exporter] *** Image ID: b1d1366a55957404dbff9f298c59d417dc5a463164b52c5a640d03fb521d1773
[exporter] Reusing tarball for layer "heroku/nodejs-engine:nodejs" with SHA: sha256:328f283f7e972466b23ac2cc19bb9a4dae9937b66447e4b03da4f24b59e52972
[exporter] Reusing cache layer 'heroku/nodejs-engine:nodejs'
[exporter] Layer 'heroku/nodejs-engine:nodejs' SHA: sha256:328f283f7e972466b23ac2cc19bb9a4dae9937b66447e4b03da4f24b59e52972
[exporter] Writing tarball for layer "heroku/nodejs-engine:toolbox"
[exporter] Reusing cache layer 'heroku/nodejs-engine:toolbox'
[exporter] Layer 'heroku/nodejs-engine:toolbox' SHA: sha256:dc27a0a7afb5e54876ae28ddd037c0b274ebf5bc33dbd6a867180ad0b347198b
[exporter] Writing tarball for layer "heroku/nodejs-npm:node_modules"
[exporter] Reusing cache layer 'heroku/nodejs-npm:node_modules'
[exporter] Layer 'heroku/nodejs-npm:node_modules' SHA: sha256:4398e624fd8a263967952563328c27fb18b34594aae783d6c4fc28177623b894
[exporter] Writing tarball for layer "salesforce/nodejs-fn:dist"
[exporter] Reusing cache layer 'salesforce/nodejs-fn:dist'
[exporter] Layer 'salesforce/nodejs-fn:dist' SHA: sha256:2bfc9a30039edb1b86083e38e36ed0c455efbc48057c860d297ce01abee332c9
[exporter] Writing tarball for layer "salesforce/nodejs-fn:node_modules"
[exporter] Reusing cache layer 'salesforce/nodejs-fn:node_modules'
[exporter] Layer 'salesforce/nodejs-fn:node_modules' SHA: sha256:b969775ed39727a2bc56125027f04c5b8cfc3160902debcdf5230b55b9b3162c
Build succeeded
Building image idkman... done
```
```
» docker run -it -p 8080:8080 idkman
Starting streaming-http-adapter 0.5.4 2153adc7da97497cf041de3c70f02da229c32851

hello -> from my init
Ready to process signals
^CGraceful shutdown started
riff-invoker: 4617.961ms
```