### PR TITLE
add typescript buildpack to heroku/nodejs builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,22 @@ jobs:
       - run: docker load < pack-18-run.tar
       - run: docker load < buildpacks-18.tar
       - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
+  test-typescript-getting-started-guide:
+    docker:
+      - image: heroku/pack-runner:latest
+    steps:
+      - run: git clone https://github.com/danielleadams/typescript-getting-started.git getting_started
+      - setup_remote_docker
+      - restore_cache:
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-build.tar
+      - restore_cache:
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-pack-18-run.tar
+      - restore_cache:
+          key: v1-image-{{ .Environment.CIRCLE_SHA1 }}-buildpacks-18.tar
+      - run: docker load < pack-18-build.tar
+      - run: docker load < pack-18-run.tar
+      - run: docker load < buildpacks-18.tar
+      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:18 --no-pull
   test-evergreen-canary:
     parameters:
       url:
@@ -191,6 +207,10 @@ workflows:
       - test-getting-started-guide:
           language: node-js
           name: test-node-js
+          requires:
+            - create-service-builder
+      - test-typescript-getting-started-guide:
+          name: test-typescript
           requires:
             - create-service-builder
       - test-getting-started-guide:

--- a/builder.toml
+++ b/builder.toml
@@ -59,6 +59,10 @@ version = "0.8.0"
   uri = "https://github.com/heroku/nodejs-yarn-buildpack/releases/download/v0.0.1/nodejs-yarn-buildpack-v0.0.1.tgz"
 
 [[buildpacks]]
+  id = "heroku/nodejs-typescript"
+  uri = "https://github.com/heroku/nodejs-typescript-buildpack/releases/download/v0.0.2/nodejs-typescript-buildpack-v0.0.2.tgz"
+
+[[buildpacks]]
   id = "heroku/nodejs"
   uri = "buildpacks/heroku_nodejs"
 

--- a/buildpacks/heroku_nodejs/buildpack.toml
+++ b/buildpacks/heroku_nodejs/buildpack.toml
@@ -15,6 +15,11 @@ name = "Node.js"
     version = "0.0.1"
 
   [[order.group]]
+    id = "heroku/nodejs-typescript"
+    version = "0.0.2"
+    optional = true
+
+  [[order.group]]
     id = "heroku/procfile"
     version = "0.5"
     optional = true
@@ -27,6 +32,11 @@ name = "Node.js"
   [[order.group]]
     id = "heroku/nodejs-npm"
     version = "0.2.0"
+
+  [[order.group]]
+    id = "heroku/nodejs-typescript"
+    version = "0.0.2"
+    optional = true
 
   [[order.group]]
     id = "heroku/procfile"


### PR DESCRIPTION
Adds TypeScript buildpack from release v0.0.2. For now, the buildpack is only available in the Heroku meta buildpack.

This pull request also includes an added test in CI. The getting started guide (https://github.com/danielleadams/typescript-getting-started) is being reviewed by Salesforce OSS, so it will be able to use the same Job once the repo gets approved.

## Context
As we move towards creating a great Node experience for JavaScript developers, we want to make sure that the TypeScript experience is just as good. By adding supporting a TS buildpack, we can make data and feedback-based enhancements to the DX for developers using CNBs.