### PR TITLE
Bump nodejs-sf-fx-buildback to new 1.6.0 release

### DIFF
--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.5.8"
+    version = "1.6.0"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.8/nodejs-sf-fx-buildpack-v1.5.8.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.6.0/nodejs-sf-fx-buildpack-v1.6.0.tgz"
 
 [[buildpacks]]
   id = "heroku/maven"


### PR DESCRIPTION
* Functions Middleware adds support for Cloudevents 1.0 format with `*context` values in extensions attributes rather than mixed in with function payload `data`
