### PR TITLE
Revert "Bump nodejs-sf-fx-buildback to new 1.6.0 release"

### DIFF
--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.6.0"
+    version = "1.5.8"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.6.0/nodejs-sf-fx-buildpack-v1.6.0.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.5.8/nodejs-sf-fx-buildpack-v1.5.8.tgz"
 
 [[buildpacks]]
   id = "heroku/maven"


### PR DESCRIPTION
Reverts heroku/pack-images#108. With the latest [nodejs-sf-fx-buildpack](forcedotcom/nodejs-sf-fx-buildpack) (1.6.0), canaries are failing. Lets rollback to the latest working code.

Slack conversation here: https://heroku.slack.com/archives/CQ20PPUR4/p1595346419347100

Failures here:

- https://circleci.com/workflow-run/00d8b604-719b-45f1-a605-84aa12d2c0ae?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack
- https://circleci.com/workflow-run/7f786359-077a-4983-8391-4936d1051bfb?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack
- https://circleci.com/workflow-run/4577c860-b2c9-4096-b285-7fd0198d86e2?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack