### PR TITLE
Update forcedotcom/nodejs-sf-fx-buildpack to v1.8.0

### DIFF
--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.7.0"
+    version = "1.8.0"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.7.0/nodejs-sf-fx-buildpack-v1.7.0.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.8.0/nodejs-sf-fx-buildpack-v1.8.0.tgz"
 
 [[buildpacks]]
   id = "heroku/maven"


### PR DESCRIPTION
Includes new SDK version compatibility functionality from https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pulls/50 and https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pulls/51.

[GUS Item](https://gus.lightning.force.com/a07B0000008NmGzIAK)