### PR TITLE
Use newer canaries in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,15 +231,15 @@ workflows:
       - test-evergreen-canary:
           name: test-canary-https-invocation-hello
           url: canary-https-invocation
-          path: hello
-          fingerprint: "d4:04:b8:b2:2d:24:f3:6e:b2:5d:5b:da:c1:82:65:00"
+          path: hello-function
+          fingerprint: "5f:51:54:de:aa:c6:91:98:3e:e9:b2:a3:94:e7:05:6d"
           requires: 
             - create-functions-builder
       - test-evergreen-canary:
           name: test-canary-logs-cli-example-function
           url: canary-logs-cli
           path: salesforce/functions/ExampleFunction
-          fingerprint: "d4:04:b8:b2:2d:24:f3:6e:b2:5d:5b:da:c1:82:65:00"
+          fingerprint: "5f:51:54:de:aa:c6:91:98:3e:e9:b2:a3:94:e7:05:6d"
           requires: 
             - create-functions-builder
       - publish-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,30 +229,16 @@ workflows:
           requires:
             - create-service-builder
       - test-evergreen-canary:
-          name: test-hilltop-sms
-          url: hilltop-theatre-terraform
-          path: sms-ticket-function
+          name: test-canary-https-invocation-hello
+          url: canary-https-invocation
+          path: hello
           fingerprint: "d4:04:b8:b2:2d:24:f3:6e:b2:5d:5b:da:c1:82:65:00"
           requires: 
             - create-functions-builder
       - test-evergreen-canary:
-          name: test-hilltop-contact
-          url: hilltop-theatre-terraform
-          path: contact-update-function
-          fingerprint: "d4:04:b8:b2:2d:24:f3:6e:b2:5d:5b:da:c1:82:65:00"
-          requires: 
-            - create-functions-builder
-      - test-evergreen-canary:
-          name: test-hilltop-notification
-          url: hilltop-theatre-terraform
-          path: notification-function
-          fingerprint: "d4:04:b8:b2:2d:24:f3:6e:b2:5d:5b:da:c1:82:65:00"
-          requires:
-            - create-functions-builder
-      - test-evergreen-canary:
-          name: test-hilltop-update
-          url: hilltop-theatre-terraform
-          path: update-seating-diagram-function
+          name: test-canary-logs-cli-example-function
+          url: canary-logs-cli
+          path: salesforce/functions/ExampleFunction
           fingerprint: "d4:04:b8:b2:2d:24:f3:6e:b2:5d:5b:da:c1:82:65:00"
           requires: 
             - create-functions-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ workflows:
           name: test-canary-logs-cli-example-function
           url: canary-logs-cli
           path: salesforce/functions/ExampleFunction
-          fingerprint: "5f:51:54:de:aa:c6:91:98:3e:e9:b2:a3:94:e7:05:6d"
+          fingerprint: "c1:1d:be:7b:33:56:47:56:8a:84:55:15:9f:7c:5e:1c"
           requires: 
             - create-functions-builder
       - publish-image:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,10 +254,8 @@ workflows:
             - test-ruby
             - test-php
             - test-python
-            - test-hilltop-sms
-            - test-hilltop-contact
-            - test-hilltop-notification
-            - test-hilltop-update
+            - test-canary-https-invocation-hello
+            - test-canary-logs-cli-example-function
           filters:
             branches:
               only: master
@@ -273,10 +271,8 @@ workflows:
             - test-ruby
             - test-php
             - test-python
-            - test-hilltop-sms
-            - test-hilltop-contact
-            - test-hilltop-notification
-            - test-hilltop-update
+            - test-canary-https-invocation-hello
+            - test-canary-logs-cli-example-function
           filters:
             branches:
               only: master


### PR DESCRIPTION
We previously leaned on https://github.com/heroku/evergreen-hilltop-theatre-terraform as canaries for validating function builders. That repository is not seeing updates as event invocation is scheduled for later delivery. We should use canaries that are actively being updated and tested instead.