### PR TITLE
Update forcedotcom/nodejs-sf-fx-buildpack to v1.9.4

### DIFF
--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.9.3"
+    version = "1.9.4"

--- a/functions-builder.toml
+++ b/functions-builder.toml
@@ -16,7 +16,7 @@ version = "0.6.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.9.3/nodejs-sf-fx-buildpack-v1.9.3.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.9.3/nodejs-sf-fx-buildpack-v1.9.4.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"


### PR DESCRIPTION
Depends on https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pull/59/files.