### PR TITLE
chore: Bump nodejs-sf-fx-buildpack to v2.0.1

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -68,7 +68,7 @@ version = "0.9.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.0/nodejs-sf-fx-buildpack-v2.0.0.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.1/nodejs-sf-fx-buildpack-v2.0.1.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/builder.toml
+++ b/builder.toml
@@ -68,7 +68,7 @@ version = "0.9.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v1.9.7/nodejs-sf-fx-buildpack-v1.9.7.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.0/nodejs-sf-fx-buildpack-v2.0.0.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "1.9.7"
+    version = "2.0.0"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "2.0.0"
+    version = "2.0.1"


### PR DESCRIPTION
This brings in the changes from forcedotcom/nodejs-sf-fx-buildpack/pull/63.