### PR TITLE
Start building heroku/pack:20 and heroku/pack:20-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,16 +5,18 @@ jobs:
       dockerfile:
         description: "Dockerfile to build"
         type: string
+      base_image:
+        description: "The Docker image to be used in the FROM line of the Dockerfile"
+        type: string
+      stack_name:
+        description: "The name of the stack"
+        type: string
       image_file:
         description: "Local image archive file name"
         type: string
       image_tag:
         description: "Remote image tag name"
         type: string
-      target:
-        description: "Docker build target"
-        type: string
-        default: ""
     docker:
       - image: heroku/pack-runner:latest
     steps:
@@ -22,7 +24,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
-      - run: docker build -f << parameters.dockerfile >> --target "<< parameters.target >>" -t << parameters.image_tag >> .
+      - run: docker build -f << parameters.dockerfile >> --build-arg STACK=<< parameters.stack_name >> --build-arg BASE_IMAGE=<< parameters.base_image >> -t << parameters.image_tag >> .
       - run: docker save << parameters.image_tag >> > /tmp/workspace/<< parameters.image_file >>
       - persist_to_workspace:
           root: /tmp/workspace
@@ -131,23 +133,41 @@ workflows:
   build-test-publish:
     jobs: &build-test-publish-jobs
       - create-image:
-          name: create-build-image
+          name: create-18-build-image
           dockerfile: Dockerfile.build
+          base_image: heroku/heroku:18-build
+          stack_name: heroku-18
           image_tag: heroku/pack:18-build
           image_file: pack-18-build.tar
       - create-image:
-          name: create-run-image
+          name: create-18-run-image
           dockerfile: Dockerfile.run
+          base_image: heroku/heroku:18
+          stack_name: heroku-18
           image_tag: heroku/pack:18
           image_file: pack-18-run.tar
+      - create-image:
+          name: create-20-build-image
+          dockerfile: Dockerfile.build
+          base_image: heroku/heroku:20-build
+          stack_name: heroku-20
+          image_tag: heroku/pack:20-build
+          image_file: pack-20-build.tar
+      - create-image:
+          name: create-20-run-image
+          dockerfile: Dockerfile.run
+          base_image: heroku/heroku:20
+          stack_name: heroku-20
+          image_tag: heroku/pack:20
+          image_file: pack-20-run.tar
       - create-pack-builder:
           name: create-service-builder
           image_tag: heroku/buildpacks:18
           image_file: buildpacks-18.tar
           builder_toml: builder.toml
           requires:
-            - create-run-image
-            - create-build-image
+            - create-18-run-image
+            - create-18-build-image
       - test-getting-started-guide:
           language: go
           name: test-go
@@ -202,7 +222,7 @@ workflows:
           requires:
             - create-service-builder
       - publish-image:
-          name: publish-build-stack
+          name: publish-18-build-stack
           image_file: pack-18-build.tar
           image_tag: heroku/pack:18-build
           image_tag_alias: heroku/pack:18-build
@@ -219,7 +239,7 @@ workflows:
             branches:
               only: master
       - publish-image:
-          name: publish-run-stack
+          name: publish-18-run-stack
           image_file: pack-18-run.tar
           image_tag: heroku/pack:18
           image_tag_alias: heroku/pack:18
@@ -241,8 +261,28 @@ workflows:
           image_tag: heroku/buildpacks:18
           image_tag_alias: heroku/buildpacks:latest
           requires:
-            - publish-build-stack
-            - publish-run-stack
+            - publish-18-build-stack
+            - publish-18-run-stack
+          filters:
+            branches:
+              only: master
+      - publish-image:
+          name: publish-20-build-stack
+          image_file: pack-20-build.tar
+          image_tag: heroku/pack:20-build
+          image_tag_alias: heroku/pack:20-build
+          requires:
+            - create-20-build-image
+          filters:
+            branches:
+              only: master
+      - publish-image:
+          name: publish-20-run-stack
+          image_file: pack-20-run.tar
+          image_tag: heroku/pack:20
+          image_tag_alias: heroku/pack:20
+          requires:
+            - create-20-run-image
           filters:
             branches:
               only: master

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,5 @@
-FROM heroku/heroku:18-build
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 ARG pack_uid=1000
 ARG pack_gid=1000
@@ -10,9 +11,11 @@ RUN mkdir /app && \
 
 ENV CNB_USER_ID=${pack_uid}
 ENV CNB_GROUP_ID=${pack_gid}
-ENV STACK "heroku-18"
-ENV CNB_STACK_ID "heroku-18"
-LABEL io.buildpacks.stack.id="heroku-18"
+
+ARG STACK
+ENV STACK "${STACK}"
+ENV CNB_STACK_ID "${STACK}"
+LABEL io.buildpacks.stack.id="${STACK}"
 
 ADD https://s3.amazonaws.com/heroku-fn-devex-staging/develop/latest/develop /cnb/lifecycle/develop
 RUN chmod +x /cnb/lifecycle/develop

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,4 +1,5 @@
-FROM heroku/heroku:18
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 RUN ln -s /workspace /app
 
@@ -8,6 +9,7 @@ ARG pack_gid=1000
 RUN groupadd heroku --gid ${pack_gid} && \
   useradd heroku -u ${pack_uid} -g ${pack_gid} -s /bin/bash -m
 
-LABEL io.buildpacks.stack.id="heroku-18"
+ARG STACK
+LABEL io.buildpacks.stack.id="${STACK}"
 USER heroku
 ENV HOME /app

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 SHELL=/bin/bash -o pipefail
 
 build:
-	@docker pull heroku/heroku:18-build
-	@docker build -f Dockerfile.build -t heroku/pack:18-build .
-	@docker build -f Dockerfile.run -t heroku/pack:18 .
+	@docker build --pull -f Dockerfile.build --build-arg STACK=heroku-18 --build-arg BASE_IMAGE=heroku/heroku:18-build -t heroku/pack:18-build .
+	@docker build --pull -f Dockerfile.build --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20-build -t heroku/pack:20-build .
+	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-18 --build-arg BASE_IMAGE=heroku/heroku:18 -t heroku/pack:18 .
+	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20 -t heroku/pack:20 .
 	@pack create-builder heroku/buildpacks:18 --builder-config builder.toml --no-pull
 	@pack create-builder heroku/spring-boot-buildpacks:18 --builder-config spring-boot-builder.toml --no-pull
 	@docker tag heroku/buildpacks:18 heroku/buildpacks:latest
@@ -13,7 +14,9 @@ build:
 
 publish: build
 	@docker push heroku/pack:18-build
+	@docker push heroku/pack:20-build
 	@docker push heroku/pack:18
+	@docker push heroku/pack:20
 	@docker push heroku/buildpacks:18
 	@docker push heroku/buildpacks:latest
 	@docker push heroku/spring-boot-buildpacks:18

--- a/README.md
+++ b/README.md
@@ -8,8 +8,12 @@ Heroku-like builds with [Cloud Native Buildpacks'](https://buildpacks.io)
 
 * [heroku/pack:18](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
   compatible run image based on heroku:18
+* [heroku/pack:20](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
+  compatible run image based on heroku:20
 * [heroku/pack:18-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
   compatible build image based on heroku:18-build
+* [heroku/pack:20-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
+  compatible build image based on heroku:20-build
 * [heroku/buildpacks:18](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
   CNB Builder that features the heroku-18 stack, heroku buildpacks, and
   Salesforce Function buildpacks


### PR DESCRIPTION
The first step for Heroku-20 support is to start building and publishing the `heroku/pack:20` and `heroku/pack:20-build` stack images.

Once these are available, CNB authors will be able to test their buildpacks against the new stack, and in a later PR we'll start publishing the `heroku/buildpacks:20` builder with the updated CNBs.

For more on the remaining Heroku-20 tasks, see:
https://salesforce.quip.com/LbhlAFPd1rvR#fCAACA6FA2X

Closes [W-8270099](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008hLTWIA2/view).