### PR TITLE
Updating Node.js buildpacks for Heroku-20 support

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -48,19 +48,19 @@ version = "0.9.2"
 
 [[buildpacks]]
   id = "heroku/nodejs-engine"
-  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.6.0/nodejs-engine-buildpack-v0.6.0.tgz"
+  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.7.0/nodejs-engine-buildpack-v0.7.0.tgz"
 
 [[buildpacks]]
   id = "heroku/nodejs-npm"
-  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.3.0/nodejs-npm-buildpack-v0.3.0.tgz"
+  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.4.0/nodejs-npm-buildpack-v0.4.0.tgz"
 
 [[buildpacks]]
   id = "heroku/nodejs-yarn"
-  uri = "https://github.com/heroku/nodejs-yarn-buildpack/releases/download/v0.0.1/nodejs-yarn-buildpack-v0.0.1.tgz"
+  uri = "https://github.com/heroku/nodejs-yarn-buildpack/releases/download/v0.1.0/nodejs-yarn-buildpack-v0.1.0.tgz"
 
 [[buildpacks]]
   id = "heroku/nodejs-typescript"
-  uri = "https://github.com/heroku/nodejs-typescript-buildpack/releases/download/v0.1.0/nodejs-typescript-buildpack-v0.1.0.tgz"
+  uri = "https://github.com/heroku/nodejs-typescript-buildpack/releases/download/v0.2.0/nodejs-typescript-buildpack-v0.2.0.tgz"
 
 [[buildpacks]]
   id = "heroku/nodejs"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -46,6 +46,26 @@ version = "0.9.2"
   id = "heroku/go"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3&name=Go"
 
+[[buildpacks]]
+  id = "heroku/nodejs-engine"
+  uri = "https://github.com/heroku/nodejs-engine-buildpack/releases/download/v0.7.0/nodejs-engine-buildpack-v0.7.0.tgz"
+
+[[buildpacks]]
+  id = "heroku/nodejs-npm"
+  uri = "https://github.com/heroku/nodejs-npm-buildpack/releases/download/v0.4.0/nodejs-npm-buildpack-v0.4.0.tgz"
+
+[[buildpacks]]
+  id = "heroku/nodejs-yarn"
+  uri = "https://github.com/heroku/nodejs-yarn-buildpack/releases/download/v0.1.0/nodejs-yarn-buildpack-v0.1.0.tgz"
+
+[[buildpacks]]
+  id = "heroku/nodejs-typescript"
+  uri = "https://github.com/heroku/nodejs-typescript-buildpack/releases/download/v0.2.0/nodejs-typescript-buildpack-v0.2.0.tgz"
+
+[[buildpacks]]
+  id = "heroku/nodejs"
+  uri = "buildpacks/heroku_nodejs"
+
 [[order]]
   [[order.group]]
     id = "heroku/ruby"
@@ -89,3 +109,7 @@ version = "0.9.2"
   [[order.group]]
     id = "heroku/procfile"
     optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -8,11 +8,11 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.6.0"
+    version = "0.7.0"
 
   [[order.group]]
     id = "heroku/nodejs-npm"
-    version = "0.3.0"
+    version = "0.4.0"
 
   [[order.group]]
     id = "projectriff/streaming-http-adapter"

--- a/buildpacks/heroku_nodejs/buildpack.toml
+++ b/buildpacks/heroku_nodejs/buildpack.toml
@@ -8,15 +8,15 @@ name = "Node.js"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.6.0"
+    version = "0.7.0"
 
   [[order.group]]
     id = "heroku/nodejs-yarn"
-    version = "0.0.1"
+    version = "0.1.0"
 
   [[order.group]]
     id = "heroku/nodejs-typescript"
-    version = "0.1.0"
+    version = "0.2.0"
     optional = true
 
   [[order.group]]
@@ -27,15 +27,15 @@ name = "Node.js"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.6.0"
+    version = "0.7.0"
 
   [[order.group]]
     id = "heroku/nodejs-npm"
-    version = "0.3.0"
+    version = "0.4.0"
 
   [[order.group]]
     id = "heroku/nodejs-typescript"
-    version = "0.1.0"
+    version = "0.2.0"
     optional = true
 
   [[order.group]]


### PR DESCRIPTION
# Changes

## nodejs-engine: 0.7.0 (2020-11-11)
### Added
- Add support for heroku-20 ([#60](https://github.com/heroku/nodejs-engine-buildpack/pull/60))

### Fixed
- Remove jq installation ([#57](https://github.com/heroku/nodejs-engine-buildpack/pull/57))
- Make `NODE_ENV` variables overrides ([#61](https://github.com/heroku/nodejs-engine-buildpack/pull/61))

## nodejs-npm: 0.4.0 (2020-11-11)
### Added
- Add heroku-20 to supported stacks ([#40](https://github.com/heroku/nodejs-npm-buildpack/pull/40))

## nodejs-yarn: 0.1.0 (2020-11-11)
### Added
- Add support for heroku-20 and bionic stacks ([#4](https://github.com/heroku/nodejs-yarn-buildpack/pull/4))

## nodejs-typescript: v0.2.0
### Added
- Add heroku-20 support and stack-specific tests ([#13](https://github.com/heroku/nodejs-typescript-buildpack/pull/13))