### PR TITLE
Update Pack to 0.15.0, lifecycle to 0.9.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - run: docker pull gcr.io/projectriff/node-function:0.6.1
       - run: docker load < $(ls /tmp/workspace/pack-*-build.tar | head -1)
       - run: docker load < $(ls /tmp/workspace/pack-*-run.tar | head -1)
-      - run: pack create-builder << parameters.image_tag >> --builder-config << parameters.builder_toml >> --no-pull
+      - run: pack create-builder << parameters.image_tag >> --config << parameters.builder_toml >> --no-pull
       - run: docker save << parameters.image_tag >> > /tmp/workspace/<< parameters.image_file >>
       - persist_to_workspace:
           root: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - run: docker pull gcr.io/projectriff/node-function:0.6.1
       - run: docker load < $(ls /tmp/workspace/pack-*-build.tar | head -1)
       - run: docker load < $(ls /tmp/workspace/pack-*-run.tar | head -1)
-      - run: pack create-builder << parameters.image_tag >> --config << parameters.builder_toml >> --no-pull
+      - run: pack create-builder << parameters.image_tag >> --config << parameters.builder_toml >> --pull-policy never
       - run: docker save << parameters.image_tag >> > /tmp/workspace/<< parameters.image_file >>
       - persist_to_workspace:
           root: /tmp/workspace
@@ -92,7 +92,7 @@ jobs:
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-run.tar
       - run: docker load < /tmp/workspace/buildpacks-<< parameters.stack-tag >>.tar
       - run: pack trust-builder heroku/buildpacks:<< parameters.stack-tag >>
-      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:<< parameters.stack-tag >> --no-pull
+      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
   test-evergreen-canary:
     parameters:
       url:
@@ -126,7 +126,7 @@ jobs:
       - run: docker load < /tmp/workspace/pack-18-build.tar
       - run: docker load < /tmp/workspace/pack-18-run.tar
       - run: docker load < /tmp/workspace/<< parameters.builder_file_name >>
-      - run: pack build pack-evergreen-canary --path evergreen-canary/src/<< parameters.path >> --builder << parameters.builder_image_tag >> --trust-builder --no-pull
+      - run: pack build pack-evergreen-canary --path evergreen-canary/src/<< parameters.path >> --builder << parameters.builder_image_tag >> --trust-builder --pull-policy never
   publish-image:
     parameters:
       image_file:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run: docker load < /tmp/workspace/buildpacks-<< parameters.stack-tag >>.tar
       - run: docker pull buildpacksio/pack:0.15.0
       - run: docker run buildpacksio/pack:0.15.0 trust-builder heroku/buildpacks:<< parameters.stack-tag >>
-      - run: docker run -v ~/project:/workspace buildpacksio/pack:0.15.0 build pack-getting-started --path getting_started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
+      - run: docker run -v ~/project/getting_started:/workspace buildpacksio/pack:0.15.0 build pack-getting-started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
   test-evergreen-canary:
     parameters:
       url:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run: docker load < /tmp/workspace/buildpacks-<< parameters.stack-tag >>.tar
       - run: docker pull buildpacksio/pack:0.15.0
       - run: docker run buildpacksio/pack:0.15.0 trust-builder heroku/buildpacks:<< parameters.stack-tag >>
-      - run: docker run -v ~/project/getting_started:/workspace buildpacksio/pack:0.15.0 build pack-getting-started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
+      - run: docker run -v /var/run/docker.sock -v ~/project/getting_started:/workspace buildpacksio/pack:0.15.0 build pack-getting-started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
   test-evergreen-canary:
     parameters:
       url:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,15 +83,16 @@ jobs:
       - image: circleci/golang:1.15
     steps:
       - run: git clone https://github.com/heroku/<< parameters.language >>-getting-started.git getting_started
+      - run: *create-docker-config
+      - run: *install-pack
       - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-build.tar
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-run.tar
       - run: docker load < /tmp/workspace/buildpacks-<< parameters.stack-tag >>.tar
-      - run: docker pull buildpacksio/pack:0.15.0
-      - run: docker run buildpacksio/pack:0.15.0 trust-builder heroku/buildpacks:<< parameters.stack-tag >>
-      - run: docker run -v /var/run/docker.sock -v ~/project/getting_started:/workspace buildpacksio/pack:0.15.0 build pack-getting-started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
+      - run: pack trust-builder heroku/buildpacks:<< parameters.stack-tag >>
+      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
   test-evergreen-canary:
     parameters:
       url:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,16 +83,15 @@ jobs:
       - image: circleci/golang:1.15
     steps:
       - run: git clone https://github.com/heroku/<< parameters.language >>-getting-started.git getting_started
-      - run: *create-docker-config
-      - run: *install-pack
       - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-build.tar
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-run.tar
       - run: docker load < /tmp/workspace/buildpacks-<< parameters.stack-tag >>.tar
-      - run: pack trust-builder heroku/buildpacks:<< parameters.stack-tag >>
-      - run: pack build pack-getting-started --path getting_started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
+      - run: docker pull buildpacksio/pack:0.15.0
+      - run: docker run buildpacksio/pack:0.15.0 trust-builder heroku/buildpacks:<< parameters.stack-tag >>
+      - run: docker run -v ~/project:/workspace buildpacksio/pack:0.15.0 build pack-getting-started --path getting_started --builder heroku/buildpacks:<< parameters.stack-tag >> --pull-policy never
   test-evergreen-canary:
     parameters:
       url:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
         description: "Remote image tag name"
         type: string
     docker:
-      - image: heroku/pack-runner:latest
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - attach_workspace:
@@ -42,9 +42,22 @@ jobs:
         description: "Remote builder image name"
         type: string
     docker:
-      - image: heroku/pack-runner:latest
+      - image: circleci/golang:1.15
     steps:
       - checkout
+      - run: &create-docker-config
+          name: "Create docker config"
+          command: |
+            mkdir -p ~/.docker
+            echo '{}' > ~/.docker/config.json
+      - run: &install-pack
+          name: "Install pack"
+          command: |
+            wget https://github.com/buildpacks/pack/releases/download/v0.15.0/pack-v0.15.0-linux.tgz
+            tar xvf pack-v0.15.0-linux.tgz
+            rm pack-v0.15.0-linux.tgz
+            mkdir -p ~/bin/
+            mv pack $HOME/bin/
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
@@ -67,9 +80,11 @@ jobs:
         description: "The tag of the run stack (ex. '20' for heroku/heroku:20)"
         type: string
     docker:
-      - image: heroku/pack-runner:latest
+      - image: circleci/golang:1.15
     steps:
       - run: git clone https://github.com/heroku/<< parameters.language >>-getting-started.git getting_started
+      - run: *create-docker-config
+      - run: *install-pack
       - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
@@ -96,9 +111,11 @@ jobs:
         description: "Builder cached image name"
         type: "string"
     docker:
-      - image: heroku/pack-runner:latest
+      - image: circleci/golang:1.15
     steps:
       - checkout
+      - run: *create-docker-config
+      - run: *install-pack
       - add_ssh_keys:
           fingerprints:
             - << parameters.fingerprint >>
@@ -122,7 +139,7 @@ jobs:
         description: "Name of dockerhub image alias to publish"
         type: string
     docker:
-      - image: heroku/pack-runner:latest
+      - image: circleci/golang:1.15
     steps:
       - setup_remote_docker
       - run: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASS

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,9 +1,0 @@
-FROM circleci/golang:1.13.7
-RUN mkdir ~/.docker
-RUN echo '{}' > ~/.docker/config.json
-RUN wget https://github.com/buildpacks/pack/releases/download/v0.11.1/pack-v0.11.1-linux.tgz
-RUN tar xvf pack-v0.11.1-linux.tgz
-RUN rm pack-v0.11.1-linux.tgz
-RUN mkdir -p $HOME/bin/
-RUN mv pack $HOME/bin/
-RUN pack --help

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,4 @@ publish: build
 	@docker push heroku/spring-boot-buildpacks:20
 	@docker push heroku/spring-boot-buildpacks:latest
 
-build-ci:
-	@docker build -f Dockerfile.ci -t heroku/pack-runner:latest .
-	@docker push heroku/pack-runner:latest
-
-.PHONY: install-buildpacks build publish build-ci create-builder-fn-local deps
+.PHONY: install-buildpacks build publish create-builder-fn-local deps

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.9.2"
+version = "0.9.3"
 
 [[buildpacks]]
   id = "heroku/maven"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:20-build"
 run-image = "heroku/pack:20"
 
 [lifecycle]
-version = "0.9.2"
+version = "0.9.3"
 
 [[buildpacks]]
   id = "heroku/maven"

--- a/spring-boot-builder-18.toml
+++ b/spring-boot-builder-18.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.9.2"
+version = "0.9.3"
 
 [[buildpacks]]
   id = "heroku/jvm"

--- a/spring-boot-builder-20.toml
+++ b/spring-boot-builder-20.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:20-build"
 run-image = "heroku/pack:20"
 
 [lifecycle]
-version = "0.9.2"
+version = "0.9.3"
 
 [[buildpacks]]
   id = "heroku/jvm"


### PR DESCRIPTION
This PR updates pack to 0.15.0 and lifecycle to 0.9.3.

It also drops the custom CI image in favor of inline pack installation, since that workflow was manual and completely undocumented.