### PR TITLE
Update java buildpacks

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -8,11 +8,11 @@ version = "0.9.2"
 
 [[buildpacks]]
   id = "heroku/maven"
-  uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/cnb-0.1/heroku-buildpack-maven.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/v68/heroku-java-cnb-v68.tgz"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v110-cnb/heroku-jvm-common-cnb-v110-cnb.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -8,11 +8,11 @@ version = "0.9.2"
 
 [[buildpacks]]
   id = "heroku/maven"
-  uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/cnb-0.1/heroku-buildpack-maven.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-java/releases/download/v68/heroku-java-cnb-v68.tgz"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v110-cnb/heroku-jvm-common-cnb-v110-cnb.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/spring-boot-builder-18.toml
+++ b/spring-boot-builder-18.toml
@@ -8,7 +8,7 @@ version = "0.9.2"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v110-cnb/heroku-jvm-common-cnb-v110-cnb.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
 
 [[buildpacks]]
   id = "heroku/spring-boot"

--- a/spring-boot-builder-20.toml
+++ b/spring-boot-builder-20.toml
@@ -8,7 +8,7 @@ version = "0.9.2"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v110-cnb/heroku-jvm-common-cnb-v110-cnb.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
 
 [[buildpacks]]
   id = "heroku/spring-boot"


### PR DESCRIPTION
Update buildpack URIs for several builders. The new versions are:

heroku/maven (heroku/java): v68
heroku/jvm: v111