### PR TITLE
Update nodejs-fn buildpack to 2.0.2

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -68,7 +68,7 @@ version = "0.9.3"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.1/nodejs-sf-fx-buildpack-v2.0.1.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.2/nodejs-sf-fx-buildpack-v2.0.2.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "2.0.1"
+    version = "2.0.2"


### PR DESCRIPTION
This brings in the update from https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pull/65.