### PR TITLE
Update heroku/jvm to v113

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -12,7 +12,7 @@ version = "0.9.3"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v113/heroku-jvm-common-cnb-v113.tgz"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -12,7 +12,7 @@ version = "0.9.3"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v113/heroku-jvm-common-cnb-v113.tgz"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/buildpacks/heroku_java/buildpack.toml
+++ b/buildpacks/heroku_java/buildpack.toml
@@ -8,7 +8,7 @@ name = "Java"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "0.1"
+    version = "0.1.0"
 
   [[order.group]]
     id = "heroku/maven"


### PR DESCRIPTION
Updates heroku/jvm to v113. Note that this version changed the CNB version from `0.1` to `0.1.0`.