### PR TITLE
Revert "Update to node-fn 2.0.3"

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -68,7 +68,7 @@ version = "0.9.3"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.3/nodejs-sf-fx-buildpack-v2.0.3.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.2/nodejs-sf-fx-buildpack-v2.0.2.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "2.0.3"
+    version = "2.0.2"


### PR DESCRIPTION
The previous sf-fx-buildpack update prevents functions from starting correctly. See https://heroku.slack.com/archives/CHYJ2J0QL/p1608140902106100.

Reverts heroku/pack-images#142