### PR TITLE
Bump lifecycle version to 0.10.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,9 @@ jobs:
       - run: &install-pack
           name: "Install pack"
           command: |
-            wget https://github.com/buildpacks/pack/releases/download/v0.15.0/pack-v0.15.0-linux.tgz
-            tar xvf pack-v0.15.0-linux.tgz
-            rm pack-v0.15.0-linux.tgz
+            wget https://github.com/buildpacks/pack/releases/download/v0.15.1/pack-v0.15.1-linux.tgz
+            tar xvf pack-v0.15.1-linux.tgz
+            rm pack-v0.15.1-linux.tgz
             mkdir -p ~/bin/
             mv pack $HOME/bin/
       - attach_workspace:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ build:
 	@docker build --pull -f Dockerfile.build --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20-build -t heroku/pack:20-build .
 	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-18 --build-arg BASE_IMAGE=heroku/heroku:18 -t heroku/pack:18 .
 	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20 -t heroku/pack:20 .
-	@pack create-builder heroku/buildpacks:18 --builder-config builder-18.toml --no-pull
-	@pack create-builder heroku/buildpacks:20 --builder-config builder-20.toml --no-pull
-	@pack create-builder heroku/spring-boot-buildpacks:18 --builder-config spring-boot-builder-18.toml --no-pull
-	@pack create-builder heroku/spring-boot-buildpacks:20 --builder-config spring-boot-builder-20.toml --no-pull
+	@pack create-builder heroku/buildpacks:18 --config builder-18.toml --pull-policy if-not-present
+	@pack create-builder heroku/buildpacks:20 --config builder-20.toml --pull-policy if-not-present
+	@pack create-builder heroku/spring-boot-buildpacks:18 --config spring-boot-builder-18.toml --pull-policy if-not-present
+	@pack create-builder heroku/spring-boot-buildpacks:20 --config spring-boot-builder-20.toml --pull-policy if-not-present
 	@docker tag heroku/buildpacks:18 heroku/buildpacks:latest
 	@docker tag heroku/spring-boot-buildpacks:18 heroku/spring-boot-buildpacks:latest
 
@@ -25,5 +25,3 @@ publish: build
 	@docker push heroku/spring-boot-buildpacks:18
 	@docker push heroku/spring-boot-buildpacks:20
 	@docker push heroku/spring-boot-buildpacks:latest
-
-.PHONY: install-buildpacks build publish create-builder-fn-local deps

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.9.3"
+version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/maven"
@@ -72,11 +72,11 @@ version = "0.9.3"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"
-  image = "gcr.io/projectriff/streaming-http-adapter:0.1.3"
+  uri = "docker://gcr.io/projectriff/streaming-http-adapter:0.1.3"
 
 [[buildpacks]]
   id = "projectriff/node-function"
-  image = "gcr.io/projectriff/node-function:0.6.1"
+  uri = "docker://gcr.io/projectriff/node-function:0.6.1"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:20-build"
 run-image = "heroku/pack:20"
 
 [lifecycle]
-version = "0.9.3"
+version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/maven"

--- a/spring-boot-builder-18.toml
+++ b/spring-boot-builder-18.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.9.3"
+version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/jvm"

--- a/spring-boot-builder-20.toml
+++ b/spring-boot-builder-20.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:20-build"
 run-image = "heroku/pack:20"
 
 [lifecycle]
-version = "0.9.3"
+version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/jvm"


### PR DESCRIPTION
- Update to lifecycle 0.10.1 on all our builders
- Update to pack 0.15.1 in circle ci and update cli usage
- Update Makefile to successfully build with updated version of pack while only pulling images not on the local machine
- Updated builder image references to use docker:// as suggested by pack upon failure