### PR TITLE
Upgrade nodejs-sf-fx buildpack to 2.0.4

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -68,7 +68,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.2/nodejs-sf-fx-buildpack-v2.0.2.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.4/nodejs-sf-fx-buildpack-v2.0.4.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,4 +24,4 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "2.0.2"
+    version = "2.0.4"


### PR DESCRIPTION
This brings in the changes from https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pull/67. This should allow functions to be built from nested source code directories.