### PR TITLE
Add evergreen_fn buildpacks to heroku/buildpacks:20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
-      - run: docker pull gcr.io/projectriff/streaming-http-adapter:0.1.3
-      - run: docker pull gcr.io/projectriff/node-function:0.6.1
+      - run: docker pull gcr.io/projectriff/streaming-http-adapter:1.4.0
+      - run: docker pull gcr.io/projectriff/node-function:1.5.0
       - run: docker load < $(ls /tmp/workspace/pack-*-build.tar | head -1)
       - run: docker load < $(ls /tmp/workspace/pack-*-run.tar | head -1)
       - run: pack create-builder << parameters.image_tag >> --config << parameters.builder_toml >> --pull-policy never
@@ -98,8 +98,8 @@ jobs:
       - run: docker exec getting-started true 2>/dev/null || (echo not running && docker logs getting-started && exit 1)
   test-evergreen-canary:
     parameters:
-      url:
-        description: "Evergreen canaries github repo"
+      canary:
+        description: "Evergreen canary name"
         type: string
       path:
         description: "Build path"
@@ -107,12 +107,9 @@ jobs:
       fingerprint:
         description: "Github private repo SSH key"
         type: string
-      builder_image_tag:
-        description: "Builder image tag to use"
-        type: "string"
-      builder_file_name:
-        description: "Builder cached image name"
-        type: "string"
+      stack-tag:
+        description: "The tag of the run stack (ex. '20' for heroku/heroku:20)"
+        type: string
     docker:
       - image: circleci/golang:1.15
     steps:
@@ -122,14 +119,15 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - << parameters.fingerprint >>
-      - run: git clone https://github.com/heroku/evergreen-<< parameters.url >>.git evergreen-canary
+      - run: git clone https://github.com/heroku/evergreen-<< parameters.canary >>.git evergreen-canary
       - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
-      - run: docker load < /tmp/workspace/pack-18-build.tar
-      - run: docker load < /tmp/workspace/pack-18-run.tar
-      - run: docker load < /tmp/workspace/<< parameters.builder_file_name >>
-      - run: pack build pack-evergreen-canary --path evergreen-canary/src/<< parameters.path >> --builder << parameters.builder_image_tag >> --trust-builder --pull-policy never
+      - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-build.tar
+      - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-run.tar
+      - run: docker load < /tmp/workspace/buildpacks-<< parameters.stack-tag >>.tar
+      - run: pack trust-builder heroku/buildpacks:<< parameters.stack-tag >>
+      - run: pack build pack-evergreen-canary --path evergreen-canary/src/<< parameters.path >> --builder heroku/buildpacks:<< parameters.stack-tag >> --trust-builder --pull-policy never
       - run: docker run --name evergreen-canary -d pack-evergreen-canary
       - run: sleep 5
       - run: docker exec evergreen-canary true 2>/dev/null || (echo not running && docker logs evergreen-canary && exit 1)
@@ -276,23 +274,37 @@ workflows:
           requires:
             - create-service-builder-20
       - test-evergreen-canary:
-          name: test-canary-https-invocation-builder
-          url: canary-https-invocation
+          name: test-canary-https-invocation-builder-18
+          canary: canary-https-invocation
           path: hello-function
           fingerprint: "5f:51:54:de:aa:c6:91:98:3e:e9:b2:a3:94:e7:05:6d"
-          builder_image_tag: "heroku/buildpacks:18"
-          builder_file_name: buildpacks-18.tar
+          stack-tag: "18"
           requires:
             - create-service-builder-18
       - test-evergreen-canary:
-          name: test-canary-logs-cli-builder
-          url: canary-logs-cli
+          name: test-canary-https-invocation-builder-20
+          canary: canary-https-invocation
+          path: hello-function
+          fingerprint: "5f:51:54:de:aa:c6:91:98:3e:e9:b2:a3:94:e7:05:6d"
+          stack-tag: "20"
+          requires:
+            - create-service-builder-20
+      - test-evergreen-canary:
+          name: test-canary-logs-cli-builder-18
+          canary: canary-logs-cli
           path: salesforce/functions/ExampleFunction
           fingerprint: "c1:1d:be:7b:33:56:47:56:8a:84:55:15:9f:7c:5e:1c"
-          builder_image_tag: "heroku/buildpacks:18"
-          builder_file_name: buildpacks-18.tar
+          stack-tag: "18"
           requires:
             - create-service-builder-18
+      - test-evergreen-canary:
+          name: test-canary-logs-cli-builder-20
+          canary: canary-logs-cli
+          path: salesforce/functions/ExampleFunction
+          fingerprint: "c1:1d:be:7b:33:56:47:56:8a:84:55:15:9f:7c:5e:1c"
+          stack-tag: "20"
+          requires:
+            - create-service-builder-20
       - publish-image:
           name: publish-18-build-stack
           image_file: pack-18-build.tar
@@ -305,8 +317,8 @@ workflows:
             - test-ruby-18
             - test-php-18
             - test-python-18
-            - test-canary-https-invocation-builder
-            - test-canary-logs-cli-builder
+            - test-canary-https-invocation-builder-18
+            - test-canary-logs-cli-builder-18
           filters:
             branches:
               only: master
@@ -322,8 +334,8 @@ workflows:
             - test-ruby-18
             - test-php-18
             - test-python-18
-            - test-canary-https-invocation-builder
-            - test-canary-logs-cli-builder
+            - test-canary-https-invocation-builder-18
+            - test-canary-logs-cli-builder-18
           filters:
             branches:
               only: master
@@ -349,6 +361,8 @@ workflows:
             - test-java-20
             - test-php-20
             - test-python-20
+            - test-canary-https-invocation-builder-20
+            - test-canary-logs-cli-builder-20
           filters:
             branches:
               only: master
@@ -363,6 +377,8 @@ workflows:
             - test-java-20
             - test-php-20
             - test-python-20
+            - test-canary-https-invocation-builder-20
+            - test-canary-logs-cli-builder-20
           filters:
             branches:
               only: master

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -68,15 +68,15 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.4/nodejs-sf-fx-buildpack-v2.0.4.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.5/nodejs-sf-fx-buildpack-v2.0.5.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"
-  uri = "docker://gcr.io/projectriff/streaming-http-adapter:0.1.3"
+  uri = "docker://gcr.io/projectriff/streaming-http-adapter:1.4.0"
 
 [[buildpacks]]
   id = "projectriff/node-function"
-  uri = "docker://gcr.io/projectriff/node-function:0.6.1"
+  uri = "docker://gcr.io/projectriff/node-function:1.5.0"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -66,6 +66,22 @@ version = "0.10.1"
   id = "heroku/nodejs"
   uri = "buildpacks/heroku_nodejs"
 
+[[buildpacks]]
+  id = "salesforce/nodejs-fn"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.5/nodejs-sf-fx-buildpack-v2.0.5.tgz"
+
+[[buildpacks]]
+  id = "projectriff/streaming-http-adapter"
+  uri = "docker://gcr.io/projectriff/streaming-http-adapter:1.4.0"
+
+[[buildpacks]]
+  id = "projectriff/node-function"
+  uri = "docker://gcr.io/projectriff/node-function:1.5.0"
+
+[[buildpacks]]
+  id = "evergreen/fn"
+  uri = "buildpacks/evergreen_fn"
+
 [[order]]
   [[order.group]]
     id = "heroku/ruby"
@@ -109,6 +125,10 @@ version = "0.10.1"
   [[order.group]]
     id = "heroku/procfile"
     optional = true
+
+[[order]]
+  [[order.group]]
+    id = "evergreen/fn"
 
 [[order]]
   [[order.group]]

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -16,12 +16,12 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "projectriff/streaming-http-adapter"
-    version = "0.1.3"
+    version = "1.4.0"
 
   [[order.group]]
     id = "projectriff/node-function"
-    version = "0.6.1"
+    version = "1.5.0"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "2.0.4"
+    version = "2.0.5"


### PR DESCRIPTION
- Bumped versions of evergreen_fn metabuildpack to versions compatible with `heroku-20` and `heroku-18` stacks.
- Added canary tests to workflow for publishling `heroku/buildpacks:20` in CircleCI

Signed-off-by: Jesse Brown <jabrown85@gmail.com>