### PR TITLE
Bump salesforce/nodejs-fn to 2.0.6

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -72,7 +72,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.5/nodejs-sf-fx-buildpack-v2.0.5.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.6/nodejs-sf-fx-buildpack-v2.0.6.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -72,7 +72,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
-  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.5/nodejs-sf-fx-buildpack-v2.0.5.tgz"
+  uri = "https://github.com/forcedotcom/nodejs-sf-fx-buildpack/releases/download/v2.0.6/nodejs-sf-fx-buildpack-v2.0.6.tgz"
 
 [[buildpacks]]
   id = "projectriff/streaming-http-adapter"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -24,7 +24,7 @@ name = "Evergreen Function"
 
   [[order.group]]
     id = "salesforce/nodejs-fn"
-    version = "2.0.5"
+    version = "2.0.6"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
Bump buildpack to bring in proper cache busting for stack changes.

Ref: https://github.com/forcedotcom/nodejs-sf-fx-buildpack/pull/70