### PR TITLE
update heroku/nodejs versions

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -53,24 +53,8 @@ version = "0.10.1"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
 
 [[buildpacks]]
-  id = "heroku/nodejs-engine"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:811fc2e1ee82b8bbf186e2a7f1ffd5d3e0191d14790f473cdb30403ecaa9a076"
-
-[[buildpacks]]
-  id = "heroku/nodejs-npm"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:b55bc7270643271658fa65aac6b7ce87f73c3a7d94be1e136e9f62a736cc025f"
-
-[[buildpacks]]
-  id = "heroku/nodejs-yarn"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:18d6283e3d16614946f743ad7db0bfd987c2062c9e16d6eeb1ce9e2a26f6c876"
-
-[[buildpacks]]
-  id = "heroku/nodejs-typescript"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:4e4fa2f7b2c45ee135e0c4b0ffb5dcebf9b43ea24d490699f82f95fa64229cee"
-
-[[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c8932c038e3b380824f97af7105b8e592fa6a115ca955709469a31b2617817a7"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:33925c80a23b9592b4217fc5e8a6deea0fd412b7d2541a11610604cad131e8b4"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
@@ -146,7 +130,7 @@ version = "0.10.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.3.0"
+    version = "0.3.3"
 
 [[order]]
   [[order.group]]

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -38,7 +38,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.1"
+  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -79,7 +79,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -89,7 +89,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -99,7 +99,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -109,7 +109,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -119,7 +119,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -52,26 +52,9 @@ version = "0.10.1"
   id = "heroku/go"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
 
-
-[[buildpacks]]
-  id = "heroku/nodejs-engine"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-engine-buildpack@sha256:811fc2e1ee82b8bbf186e2a7f1ffd5d3e0191d14790f473cdb30403ecaa9a076"
-
-[[buildpacks]]
-  id = "heroku/nodejs-npm"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-npm-buildpack@sha256:b55bc7270643271658fa65aac6b7ce87f73c3a7d94be1e136e9f62a736cc025f"
-
-[[buildpacks]]
-  id = "heroku/nodejs-yarn"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-yarn-buildpack@sha256:18d6283e3d16614946f743ad7db0bfd987c2062c9e16d6eeb1ce9e2a26f6c876"
-
-[[buildpacks]]
-  id = "heroku/nodejs-typescript"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-typescript-buildpack@sha256:4e4fa2f7b2c45ee135e0c4b0ffb5dcebf9b43ea24d490699f82f95fa64229cee"
-
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c8932c038e3b380824f97af7105b8e592fa6a115ca955709469a31b2617817a7"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:33925c80a23b9592b4217fc5e8a6deea0fd412b7d2541a11610604cad131e8b4"
 
 [[buildpacks]]
   id = "salesforce/nodejs-fn"
@@ -147,7 +130,7 @@ version = "0.10.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.3.0"
+    version = "0.3.3"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -38,7 +38,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.1"
+  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -79,7 +79,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -89,7 +89,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -99,7 +99,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -109,7 +109,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]
@@ -119,7 +119,7 @@ version = "0.10.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.1"
+    version = "0.6.2"
     optional = true
 
 [[order]]

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -8,7 +8,7 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.3.0"
+    version = "0.3.3"
 
   [[order.group]]
     id = "projectriff/streaming-http-adapter"


### PR DESCRIPTION
Updates the Node.js buildpacks and removes the referenced buildpacks that are no longer needed in favor of the meta buildpack. Also upgrades the `procfile-cnb` versions for all the referenced buildpack groups in the builders.