### PR TITLE
Revert "Update the spring-boot builder and the makefile target"

### DIFF
--- a/spring-boot-builder-18.toml
+++ b/spring-boot-builder-18.toml
@@ -8,7 +8,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v113/heroku-jvm-common-cnb-v113.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
 
 [[buildpacks]]
   id = "heroku/spring-boot"

--- a/spring-boot-builder-20.toml
+++ b/spring-boot-builder-20.toml
@@ -8,7 +8,7 @@ version = "0.10.1"
 
 [[buildpacks]]
   id = "heroku/jvm"
-  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v113/heroku-jvm-common-cnb-v113.tgz"
+  uri = "https://github.com/heroku/heroku-buildpack-jvm-common/releases/download/v111/heroku-jvm-common-cnb-v111.tgz"
 
 [[buildpacks]]
   id = "heroku/spring-boot"


### PR DESCRIPTION
Reverts heroku/pack-images#144

`master` branch has not succeeded since. The error we are seeing is:

```
ERROR: failed to write image to the following tags: [heroku/buildpacks:20: image load 'heroku/buildpacks:20'. first error: embedded daemon response: invalid diffID for layer 27: expected "sha256:57a49fb084ace8d18b8b39aa70204f1e5f3b1ec979549e0805e63f11dd101e68", got "sha256:a02d3fde2aeb174a2aa54081c66d4ca7c61859ee120516d71817089c8236fa2e"]
```