### PR TITLE
Update heroku/nodejs-function buildpack

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -58,7 +58,7 @@ version = "0.11.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:1884dafde6d8fc5e40e4348f8d466a05700a374fad577ac5e187261243d0dd03"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2fb076f0b5f66599e8f0b3b7630767c6dd516c72482cde244b71a857535b3c5e"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -58,7 +58,7 @@ version = "0.11.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:1884dafde6d8fc5e40e4348f8d466a05700a374fad577ac5e187261243d0dd03"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2fb076f0b5f66599e8f0b3b7630767c6dd516c72482cde244b71a857535b3c5e"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -8,7 +8,7 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.5.0"
+    version = "0.5.1"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
## `heroku/nodejs-function` `0.5.1`
* Upgraded `heroku/nodejs-function-invoker` to `0.1.1`

## `heroku/nodejs-function-invoker` `0.1.1`
* Run check for "main" key and file in package.json ([#52](https://github.com/heroku/buildpacks-nodejs/pull/52))
* Support for newer versions of the function runtime