### PR TITLE
Update heroku/nodejs-function to 0.5.2

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -58,7 +58,7 @@ version = "0.11.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2fb076f0b5f66599e8f0b3b7630767c6dd516c72482cde244b71a857535b3c5e"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:99a68ede08880f6ba6223c985bdf555386c0cc1a5501baee1f2663f19df6ef84"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -58,7 +58,7 @@ version = "0.11.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2fb076f0b5f66599e8f0b3b7630767c6dd516c72482cde244b71a857535b3c5e"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:99a68ede08880f6ba6223c985bdf555386c0cc1a5501baee1f2663f19df6ef84"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -8,7 +8,7 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.5.1"
+    version = "0.5.2"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
# heroku/nodejs-function

## [0.5.2] 2021/05/11
* Upgraded `heroku/nodejs-function-invoker` to `0.1.2`

# heroku/nodejs-function-invoker

## [0.1.2] 2021/05/11
### Added
- Remote debugging is now enabled when the `DEBUG_PORT` environment variable is set ([#59](https://github.com/heroku/buildpacks-nodejs/pull/59))

### Changed
- The `web` process is now marked as the default process type ([#60](https://github.com/heroku/buildpacks-nodejs/pull/60))
- The function runtime download is now cleaned up after installation ([#57](https://github.com/heroku/buildpacks-nodejs/pull/57))