### PR TITLE
Update heroku/nodejs-function to 0.5.3

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -58,7 +58,7 @@ version = "0.11.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:99a68ede08880f6ba6223c985bdf555386c0cc1a5501baee1f2663f19df6ef84"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:f6f2746fae54dfe6d3befd6ee5809fb9bdb23c8367b17411b343cae592fe410c"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -58,7 +58,7 @@ version = "0.11.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:99a68ede08880f6ba6223c985bdf555386c0cc1a5501baee1f2663f19df6ef84"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:f6f2746fae54dfe6d3befd6ee5809fb9bdb23c8367b17411b343cae592fe410c"
 
 [[buildpacks]]
   id = "evergreen/fn"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -8,7 +8,7 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.5.2"
+    version = "0.5.3"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
# heroku/nodejs-function

## [0.5.3] 2021/05/12
* Upgraded `heroku/nodejs-function-invoker` to `0.1.3`

# heroku/nodejs-function-invoker

## [0.1.3] 2021/05/12
### Changed
- Fixed `NODE_OPTIONS` unbound variable error when using `DEBUG_PORT` ([#63](https://github.com/heroku/buildpacks-nodejs/pull/63))

Refs GUS-W-9260143.
