### PR TITLE
Update heroku/java-function to 0.3.9

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -30,7 +30,7 @@ version = "0.11.3"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:f8ab59af725787c3e9dd56d6b81e985fcd3c00505f75371683f917ed306af866"
+  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:691a979f275a4156d40add69975bd01a4d8a15c728c3b12be19821bf864482a4"
 
 [[buildpacks]]
   id = "heroku/ruby"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -30,7 +30,7 @@ version = "0.11.3"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:f8ab59af725787c3e9dd56d6b81e985fcd3c00505f75371683f917ed306af866"
+  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:691a979f275a4156d40add69975bd01a4d8a15c728c3b12be19821bf864482a4"
 
 [[buildpacks]]
   id = "heroku/ruby"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -13,4 +13,4 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.8"
+    version = "0.3.9"


### PR DESCRIPTION
## `heroku/java-function` `0.3.9`
* Upgraded `heroku/jvm-function-invoker` to `0.2.8`

## `heroku/jvm-function-invoker` `0.2.8`
* `SF_FX_REMOTE_DEBUG` was renamed to `DEBUG_PORT` and also species the port on with the JDWP agent will listen on.
* Updated function runtime to `0.2.1`
* Update `bin/detect` to check for `type=function`.