### PR TITLE
Update heroku/java-function to 0.3.11

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -30,7 +30,7 @@ version = "0.11.3"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:8d747d45eab8923edb42394cd5aa2e2888b0d86c4105db4876e1ce928ce3811b"
+  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:3c03f0b960e84fefb267757e4ae247aeabfe3255a8777c3b039c0671a95a8b9c"
 
 [[buildpacks]]
   id = "heroku/ruby"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -30,7 +30,7 @@ version = "0.11.3"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:8d747d45eab8923edb42394cd5aa2e2888b0d86c4105db4876e1ce928ce3811b"
+  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-function-buildpack@sha256:3c03f0b960e84fefb267757e4ae247aeabfe3255a8777c3b039c0671a95a8b9c"
 
 [[buildpacks]]
   id = "heroku/ruby"

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -13,4 +13,4 @@ name = "Evergreen Function"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.10"
+    version = "0.3.11"


### PR DESCRIPTION
## `heroku/java-function` `0.3.11`
* Upgraded `heroku/jvm-function-invoker` to `0.2.10`

## `heroku/jvm-function-invoker` `0.2.10`
* Updated function runtime to `0.2.3`
