### PR TITLE
Update heroku/nodejs to 0.3.6

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -54,7 +54,7 @@ version = "0.11.3"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c6e6ac7d7b33eff017318c9b19a57df73e923d9643be8e6cddf9be013a14e4a0"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:b43e71d5338657097582cd48ba27fb0970ace81e08ac25dcf9bbd2659b9f8b14"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -122,7 +122,7 @@ version = "0.11.3"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.3.5"
+    version = "0.3.6"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -54,7 +54,7 @@ version = "0.11.3"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c6e6ac7d7b33eff017318c9b19a57df73e923d9643be8e6cddf9be013a14e4a0"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:b43e71d5338657097582cd48ba27fb0970ace81e08ac25dcf9bbd2659b9f8b14"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -122,7 +122,7 @@ version = "0.11.3"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.3.5"
+    version = "0.3.6"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
## `heroku/nodejs`
### [0.3.6] 2021/06/17
* Upgraded `heroku/nodejs-yarn` to `0.1.5`

## `heroku/yarn`
### [0.1.5] 2021/06/17
- Empty cache builds no longer fail with a `PREV_NODE_VERSION ` unbound variable error ([#86](https://github.com/heroku/buildpacks-node/pull/86))

Refs GUS-W-9481665.