### PR TITLE
Update lifecycle to 0.11.4

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -6,7 +6,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.11.3"
+version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/maven"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -6,7 +6,7 @@ build-image = "heroku/pack:20-build"
 run-image = "heroku/pack:20"
 
 [lifecycle]
-version = "0.11.3"
+version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/maven"

--- a/spring-boot-builder-18.toml
+++ b/spring-boot-builder-18.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:18-build"
 run-image = "heroku/pack:18"
 
 [lifecycle]
-version = "0.11.3"
+version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/jvm"

--- a/spring-boot-builder-20.toml
+++ b/spring-boot-builder-20.toml
@@ -4,7 +4,7 @@ build-image = "heroku/pack:20-build"
 run-image = "heroku/pack:20"
 
 [lifecycle]
-version = "0.11.3"
+version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/jvm"


### PR DESCRIPTION
https://github.com/buildpacks/lifecycle/releases/tag/v0.11.4
https://github.com/buildpacks/lifecycle/compare/v0.11.3...v0.11.4

Of note, this includes a fix for correctly outputting the logs when a buildpack's build plan fails to parse.

Fixes GUS-W-9666164.