### PR TITLE
Update heroku/nodejs-function to 0.5.9

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -58,7 +58,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:52be2525d715cb105c8e9e5ad06fe8713fddc7f05f6c5cfeeb2f6a49289fad81"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:167d16263e1c37a0405f23ece261800ccda15e17a5fbe2f7f4408b588b4ec726"
 
 [[buildpacks]]
   id = "evergreen/fn"
@@ -117,7 +117,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "evergreen/fn"
-    version = "0.3.1"
+    version = "0.3.2"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -58,7 +58,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:52be2525d715cb105c8e9e5ad06fe8713fddc7f05f6c5cfeeb2f6a49289fad81"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:167d16263e1c37a0405f23ece261800ccda15e17a5fbe2f7f4408b588b4ec726"
 
 [[buildpacks]]
   id = "evergreen/fn"
@@ -117,7 +117,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "evergreen/fn"
-    version = "0.3.1"
+    version = "0.3.2"
 
 [[order]]
   [[order.group]]

--- a/buildpacks/evergreen_fn/buildpack.toml
+++ b/buildpacks/evergreen_fn/buildpack.toml
@@ -2,13 +2,13 @@ api = "0.2"
 
 [buildpack]
 id = "evergreen/fn"
-version = "0.3.1"
+version = "0.3.2"
 name = "Evergreen Function"
 
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.5.7"
+    version = "0.5.9"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
Shas from:
https://github.com/buildpacks/registry-index/blob/dbd48061c39e3d32e7a309303b179aed9dc5a2db/no/de/heroku_nodejs-function#L11

Closes GUS-W-9501671.