### PR TITLE
Remove redundant JVM buildpack dependencies

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -9,20 +9,8 @@ run-image = "heroku/pack:18"
 version = "0.11.4"
 
 [[buildpacks]]
-  id = "heroku/maven"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack@sha256:de5997ef358f4b490df3b24386f00665c20c31aeab600856e144fdd62a4c50fb"
-
-[[buildpacks]]
-  id = "heroku/jvm"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack@sha256:b46824bb8a037c459d7544fe0ea88b313694c55f194feb0ec1c27b9144768070"
-
-[[buildpacks]]
   id = "heroku/java"
   uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-buildpack@sha256:3e3282fafbd80aeee8c6a847b0ae25619983086951d9b6179bd8ba348fd4f89c"
-
-[[buildpacks]]
-  id = "heroku/gradle"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack@sha256:7163f393470de8255fe03e06d55d3ae7bf59bf683f4ff2651ed92b6538eed0ad"
 
 [[buildpacks]]
   id = "heroku/scala"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -9,20 +9,8 @@ run-image = "heroku/pack:20"
 version = "0.11.4"
 
 [[buildpacks]]
-  id = "heroku/maven"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-maven-buildpack@sha256:de5997ef358f4b490df3b24386f00665c20c31aeab600856e144fdd62a4c50fb"
-
-[[buildpacks]]
-  id = "heroku/jvm"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-jvm-buildpack@sha256:b46824bb8a037c459d7544fe0ea88b313694c55f194feb0ec1c27b9144768070"
-
-[[buildpacks]]
   id = "heroku/java"
   uri = "docker://public.ecr.aws/r2f9u0w4/heroku-java-buildpack@sha256:3e3282fafbd80aeee8c6a847b0ae25619983086951d9b6179bd8ba348fd4f89c"
-
-[[buildpacks]]
-  id = "heroku/gradle"
-  uri = "docker://public.ecr.aws/r2f9u0w4/heroku-gradle-buildpack@sha256:7163f393470de8255fe03e06d55d3ae7bf59bf683f4ff2651ed92b6538eed0ad"
 
 [[buildpacks]]
   id = "heroku/scala"


### PR DESCRIPTION
These buildpacks are already transitive dependencies of `heroku/java` ([manifest](https://github.com/heroku/buildpacks-jvm/blob/270f75993d0173b1184535df73f6df440e6ea009/meta-buildpacks/java/package.toml)), and are not specified separately in the detection order.

Removing them does not stop someone from using those buildpacks individually (they will still be in the final builder image), but reduces the number of image URLs that must be updated each time a release occurs.

This came up in:
https://github.com/heroku/pack-images/pull/187#pullrequestreview-717771917

Fixes GUS-W-9672375.