### PR TITLE
Update Pack CLI from 0.15.1 to 0.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,8 @@ jobs:
       - run: &install-pack
           name: "Install pack"
           command: |
-            wget https://github.com/buildpacks/pack/releases/download/v0.15.1/pack-v0.15.1-linux.tgz
-            tar xvf pack-v0.15.1-linux.tgz
-            rm pack-v0.15.1-linux.tgz
-            mkdir -p ~/bin/
-            mv pack $HOME/bin/
+            mkdir -p ~/bin
+            curl -sSfL https://github.com/buildpacks/pack/releases/download/v0.20.0/pack-v0.20.0-linux.tgz | tar -xzC ~/bin pack
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker


### PR DESCRIPTION
https://github.com/buildpacks/pack/releases/tag/v0.16.0
https://github.com/buildpacks/pack/releases/tag/v0.17.0
https://github.com/buildpacks/pack/releases/tag/v0.18.0
https://github.com/buildpacks/pack/releases/tag/v0.18.1
https://github.com/buildpacks/pack/releases/tag/v0.19.0
https://github.com/buildpacks/pack/releases/tag/v0.20.0
https://github.com/buildpacks/pack/compare/v0.15.1...v0.20.0

Fixes GUS-W-9683933.