### PR TITLE
Include node-js-20 and typescript-20 in the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,9 +255,21 @@ workflows:
           requires:
             - create-service-builder-18
       - test-getting-started-guide:
+          language: node-js
+          stack-tag: "20"
+          name: test-node-js-20
+          requires:
+            - create-service-builder-20
+      - test-getting-started-guide:
           language: typescript
           stack-tag: "18"
           name: test-typescript-18
+          requires:
+            - create-service-builder-18
+      - test-getting-started-guide:
+          language: typescript
+          stack-tag: "20"
+          name: test-typescript-20
           requires:
             - create-service-builder-18
       - test-getting-started-guide:
@@ -338,6 +350,7 @@ workflows:
             - test-java-18
             - test-node-js-18
             - test-ruby-18
+            - test-typescript-18
             - test-php-18
             - test-python-18
             - test-canary-https-invocation-builder-18
@@ -354,6 +367,7 @@ workflows:
             - test-go-18
             - test-java-18
             - test-node-js-18
+            - test-typescript-18
             - test-ruby-18
             - test-php-18
             - test-python-18
@@ -385,6 +399,8 @@ workflows:
             - test-java-20
             - test-php-20
             - test-python-20
+            - test-node-js-20
+            - test-typescript-20
             - test-canary-https-invocation-builder-20
             - test-canary-logs-cli-builder-20
           filters:
@@ -401,6 +417,8 @@ workflows:
             - test-java-20
             - test-php-20
             - test-python-20
+            - test-node-js-20
+            - test-typescript-20
             - test-canary-https-invocation-builder-20
             - test-canary-logs-cli-builder-20
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,15 +346,15 @@ workflows:
           image_tag: heroku/pack:18-build
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-18:build
           requires:
+            - test-canary-https-invocation-builder-18
+            - test-canary-logs-cli-builder-18
             - test-go-18
             - test-java-18
             - test-node-js-18
-            - test-ruby-18
-            - test-typescript-18
             - test-php-18
             - test-python-18
-            - test-canary-https-invocation-builder-18
-            - test-canary-logs-cli-builder-18
+            - test-ruby-18
+            - test-typescript-18
           filters:
             branches:
               only: master
@@ -364,15 +364,15 @@ workflows:
           image_tag: heroku/pack:18
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-18:run
           requires:
+            - test-canary-https-invocation-builder-18
+            - test-canary-logs-cli-builder-18
             - test-go-18
             - test-java-18
             - test-node-js-18
-            - test-typescript-18
-            - test-ruby-18
             - test-php-18
             - test-python-18
-            - test-canary-https-invocation-builder-18
-            - test-canary-logs-cli-builder-18
+            - test-ruby-18
+            - test-typescript-18
           filters:
             branches:
               only: master
@@ -394,15 +394,15 @@ workflows:
           image_tag: heroku/pack:20-build
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-20:build
           requires:
-            - test-go-20
-            - test-ruby-20
-            - test-java-20
-            - test-php-20
-            - test-python-20
-            - test-node-js-20
-            - test-typescript-20
             - test-canary-https-invocation-builder-20
             - test-canary-logs-cli-builder-20
+            - test-go-20
+            - test-java-20
+            - test-node-js-20
+            - test-php-20
+            - test-python-20
+            - test-ruby-20
+            - test-typescript-20
           filters:
             branches:
               only: master
@@ -412,15 +412,15 @@ workflows:
           image_tag: heroku/pack:20
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-20:run
           requires:
-            - test-go-20
-            - test-ruby-20
-            - test-java-20
-            - test-php-20
-            - test-python-20
-            - test-node-js-20
-            - test-typescript-20
             - test-canary-https-invocation-builder-20
             - test-canary-logs-cli-builder-20
+            - test-go-20
+            - test-java-20
+            - test-node-js-20
+            - test-php-20
+            - test-python-20
+            - test-ruby-20
+            - test-typescript-20
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ workflows:
           stack-tag: "20"
           name: test-typescript-20
           requires:
-            - create-service-builder-18
+            - create-service-builder-20
       - test-getting-started-guide:
           language: php
           stack-tag: "18"


### PR DESCRIPTION
There were a few deficiencies in the Circle Job that are being corrected here:

- We weren't testing the NodeJS or Typescript guide on heroku-20. 
- We weren't gating the heroku-20 releases on NodeJS or Typescript builds
- We weren't gating the heroku-18 releases on Typescript builds

[GUS Item](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07AH000000Ow0xYAC)