### PR TITLE
Update heroku/nodejs-function buildpack to 0.6.0

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -46,7 +46,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:167d16263e1c37a0405f23ece261800ccda15e17a5fbe2f7f4408b588b4ec726"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:ba460ab0cb2f0147c09f22680761e7a6b24607f97dfd8b82bb7cffe1bf82ff58"
 
 [[order]]
   [[order.group]]
@@ -101,7 +101,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.5.9"
+    version = "0.6.0"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -46,7 +46,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:167d16263e1c37a0405f23ece261800ccda15e17a5fbe2f7f4408b588b4ec726"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:ba460ab0cb2f0147c09f22680761e7a6b24607f97dfd8b82bb7cffe1bf82ff58"
 
 [[order]]
   [[order.group]]
@@ -101,7 +101,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.5.9"
+    version = "0.6.0"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This brings in the latest heroku/nodejs-function buildpack, which includes support for JavaScript Modules / ESM in Salesforce Functions.

More on that is here: https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/99

Here's the buildpack release this PR is referencing: https://github.com/buildpacks/registry-index/issues/1734