### PR TITLE
Update heroku/java-function to v0.3.20

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.21"
+    version = "0.3.20"
 
 [[order]]
   [[order.group]]

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -18,7 +18,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:78b246c129f07bfb72b57c16643880d3ad2c4836fdbce80598342aa5d2250c23"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:b7a3e7291687a7778cf8daa9c3b11c8c12f1978c23b1e82cdc6597e62347fa1c"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.18"
+    version = "0.3.21"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.21"
+    version = "0.3.20"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -18,7 +18,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:78b246c129f07bfb72b57c16643880d3ad2c4836fdbce80598342aa5d2250c23"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:b7a3e7291687a7778cf8daa9c3b11c8c12f1978c23b1e82cdc6597e62347fa1c"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.18"
+    version = "0.3.21"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
[Release for java-function to v0.3.20](https://github.com/heroku/buildpacks-jvm/actions/runs/1287131339)
[W-9950528](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000As3fyYAB)