### PR TITLE
Update JVM buildpacks

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -10,7 +10,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:1ee76637ef8fd4836356a22956b2afe2cd8313a54c21eac2dba875a396c23042"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:2dc6e31e669a3fe762dd130aad7c4dc4e6596ef11c55329b1a61f62d7e2512a5"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:151800df7f44bdf896edf49194a92b0af31fe62e7571747364317469e1846cad"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:2d04357459e5e24bf5af5fc56432637abd4f6f6e7dc17bb6c6665a33685a0eb1"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.22"
+    version = "0.3.23"
 
 [[order]]
   [[order.group]]
@@ -116,4 +116,4 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.3.11"
+    version = "0.3.12"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -10,7 +10,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:1ee76637ef8fd4836356a22956b2afe2cd8313a54c21eac2dba875a396c23042"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:2dc6e31e669a3fe762dd130aad7c4dc4e6596ef11c55329b1a61f62d7e2512a5"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.11.4"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:151800df7f44bdf896edf49194a92b0af31fe62e7571747364317469e1846cad"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:2d04357459e5e24bf5af5fc56432637abd4f6f6e7dc17bb6c6665a33685a0eb1"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.22"
+    version = "0.3.23"
 
 [[order]]
   [[order.group]]
@@ -116,4 +116,4 @@ version = "0.11.4"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.3.11"
+    version = "0.3.12"


### PR DESCRIPTION
## `heroku/jvm@0.1.8`
### Changed
* Default version for **OpenJDK 8** is now `1.8.0_312`
* Default version for **OpenJDK 11** is now `11.0.13`
* Default version for **OpenJDK 13** is now `13.0.9`
* Default version for **OpenJDK 15** is now `15.0.5`

## `heroku/java@0.3.12`
### Changed
* Upgraded `heroku/jvm` to `0.1.8`

## `heroku/java-function@0.3.23`
### Changed
* Upgraded `heroku/jvm-function-invoker` to `0.5.5`
* Upgraded `heroku/jvm` to `0.1.8`

References: [W-8657454](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07B0000008vrF0IAI)

[heroku/jvm](https://github.com/heroku/buildpacks-jvm/actions/runs/1360401368)
[heroku/java](https://github.com/heroku/buildpacks-jvm/actions/runs/1360434840)
[heroku/java-function-invoker](https://github.com/heroku/buildpacks-jvm/actions/runs/1360638873)
[heroku/java-function](https://github.com/heroku/buildpacks-jvm/actions/runs/1360694141)
