### PR TITLE
Spike on automating pack-image file updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "toml-rb"
+gem "excon"
+gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    citrus (3.0.2)
+    excon (0.87.0)
+    rake (13.0.6)
+    toml-rb (2.0.1)
+      citrus (~> 3.0, > 3.0)
+
+PLATFORMS
+  x86_64-darwin-20
+
+DEPENDENCIES
+  excon
+  rake
+  toml-rb
+
+BUNDLED WITH
+   2.2.27

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,133 @@
+require "pathname"
+require "toml-rb"
+require 'json'
+require 'excon'
+
+def root_dir
+  Pathname(__dir__)
+end
+
+class RegistryEntry
+  attr_reader :ns, :name, :version, :yanked, :addr
+
+  def initialize(ns: , name: , version: , yanked: , addr:)
+    @ns = ns
+    @name = name
+    @version = version
+    @yanked = yanked
+    @addr = addr
+  end
+
+  def uri
+    "docker://#{addr}"
+  end
+
+  def not_yanked?
+    !yanked
+  end
+end
+
+class RegistryFetcher
+  def initialize(id)
+    @namespace, @name = id.split("/")
+    @response = nil
+    @entries = []
+    @thread = nil
+  end
+
+  def response
+    @response ||= Excon.get(raw_url)
+  end
+
+  def success?
+    response.status.to_s.start_with?("2")
+  end
+
+  def parse_line(line)
+    JSON.parse(line, symbolize_names: true)
+  rescue => e
+    warn "Could not parse line #{line.inspect}, #{e.message}"
+    # Ignore error and keep going
+  end
+
+  def last_entry(allow_yanked: false)
+    entries.reverse.detect do |entry|
+      next true if allow_yanked
+
+      entry.not_yanked?
+    end
+  end
+
+  def entries
+    raise "Failed response Status: '#{response.status}' Body: '#{response.body}' url: '#{raw_url}'" unless success?
+    return @entries if !@entries.empty?
+
+    response.body.each_line do |line|
+      hash = parse_line(line)
+      next if hash.nil?
+      @entries << RegistryEntry.new(**hash)
+    end
+    @entries
+  end
+
+  # Example:
+  #
+  #  RegistryFetcher.new("java").raw_url
+  #  # => "https://raw.githubusercontent.com/buildpacks/registry-index/main/ja/va/heroku_java"
+  def raw_url
+    "https://raw.githubusercontent.com/buildpacks/registry-index/main/#{registry_path}"
+  end
+
+  # Example:
+  #
+  #  RegistryFetcher.new("java").registry_path
+  #  # => "ja/va/heroku_java"
+  def registry_path
+    File.join(dir, "#{@namespace}_#{@name}")
+  end
+
+  def dir
+    File.join(@name[0..1], @name[2..3])
+  end
+end
+
+task "fetch:latest" do
+  skip_array = ["heroku/go", "heroku/php", "heroku/python"]
+
+  builder_files = ["builder-18.toml", "builder-20.toml"].map do |p|
+    root_dir.join(p).expand_path
+  end
+
+  # De-dup ids, create fetcher objects
+  fetcher_for_id = {}
+  builder_files.flat_map do |path|
+    TomlRB.load_file(path).fetch("buildpacks").each do |hash|
+      id = hash["id"]
+      fetcher_for_id[id] = RegistryFetcher.new(id)
+    end
+  end
+
+  builder_files.each do |path|
+    toml_hash = TomlRB.load_file(path)
+
+    toml_hash["buildpacks"].map! do |hash|
+      id = hash["id"]
+      next hash if skip_array.include?(id)
+      hash["uri"] = fetcher_for_id[id].last_entry.uri
+      hash
+    end
+
+    toml_hash["order"].map! do |order_hash|
+      order_hash["group"].map! do |hash|
+        id = hash["id"]
+        next hash if skip_array.include?(id)
+        hash["version"] = fetcher_for_id[id].last_entry.version
+        hash
+      end
+      order_hash
+    end
+
+    puts toml_hash
+    path.write(TomlRB.dump(toml_hash))
+  end
+end

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -1,119 +1,93 @@
 description = "Base builder for Heroku-18 stack, based on ubuntu:18.04 base image"
-
-[stack]
-id = "heroku-18"
-build-image = "heroku/pack:18-build"
-run-image = "heroku/pack:18"
-
 [lifecycle]
 version = "0.11.4"
-
+[stack]
+build-image = "heroku/pack:18-build"
+id = "heroku-18"
+run-image = "heroku/pack:18"
 [[buildpacks]]
-  id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e1a7081e1ffa53870229c331a9d700ae640e2a47d36085d6b2260f913dd1e7e9"
-
+id = "heroku/java"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e1a7081e1ffa53870229c331a9d700ae640e2a47d36085d6b2260f913dd1e7e9"
 [[buildpacks]]
-  id = "heroku/scala"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:39ad34bcc1766cdff4f2a4d5e88931a2f2678f5605bd56f1b6fc551f40fba70f"
-
+id = "heroku/scala"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:99b35329c3c5af4deaab1892a6ccfad9d0646fcb8bf6fe04c688f0429d95fc11"
 [[buildpacks]]
-  id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
-
+id = "heroku/java-function"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
 [[buildpacks]]
-  id = "heroku/ruby"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
-
+id = "heroku/ruby"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
 [[buildpacks]]
-  id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
-
+id = "heroku/procfile"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:2cb7e101c876056356c1112a827bcb857669e42c209cd472dc9dc7c1bbd3fe7d"
 [[buildpacks]]
-  id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
-
+id = "heroku/python"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
 [[buildpacks]]
-  id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
-
+id = "heroku/php"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
 [[buildpacks]]
-  id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
-
+id = "heroku/go"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
 [[buildpacks]]
-  id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:b43e71d5338657097582cd48ba27fb0970ace81e08ac25dcf9bbd2659b9f8b14"
-
+id = "heroku/nodejs"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:30ab86eed55dd816fa45045dd549db97c8cfd5b9c492eae79b3095a3fafaf3a5"
 [[buildpacks]]
-  id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:68d9d869c9c0ea8dd964bfdabe3330a5da09fdab8be56142f10494ee5ab0e31c"
-
+id = "heroku/nodejs-function"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:68d9d869c9c0ea8dd964bfdabe3330a5da09fdab8be56142f10494ee5ab0e31c"
 [[order]]
-  [[order.group]]
-    id = "heroku/ruby"
-    version = "0.1.3"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/ruby"
+version = "0.1.3"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/python"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/python"
+version = "0.3.1"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/scala"
-    version = "0.0.90"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/scala"
+version = "0.0.91"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/php"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/php"
+version = "0.3.1"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/go"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/go"
+version = "0.3.1"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/nodejs-function"
-    version = "0.6.8"
-
+[[order.group]]
+id = "heroku/nodejs-function"
+version = "0.6.8"
 [[order]]
-  [[order.group]]
-    id = "heroku/java-function"
-    version = "0.3.24"
-
+[[order.group]]
+id = "heroku/java-function"
+version = "0.3.24"
 [[order]]
-  [[order.group]]
-    id = "heroku/nodejs"
-    version = "0.3.6"
-
+[[order.group]]
+id = "heroku/nodejs"
+version = "0.3.8"
 [[order]]
-  [[order.group]]
-    id = "heroku/java"
-    version = "0.3.13"
+[[order.group]]
+id = "heroku/java"
+version = "0.3.13"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -1,119 +1,93 @@
 description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base image"
-
-[stack]
-id = "heroku-20"
-build-image = "heroku/pack:20-build"
-run-image = "heroku/pack:20"
-
 [lifecycle]
 version = "0.11.4"
-
+[stack]
+build-image = "heroku/pack:20-build"
+id = "heroku-20"
+run-image = "heroku/pack:20"
 [[buildpacks]]
-  id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e1a7081e1ffa53870229c331a9d700ae640e2a47d36085d6b2260f913dd1e7e9"
-
+id = "heroku/java"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e1a7081e1ffa53870229c331a9d700ae640e2a47d36085d6b2260f913dd1e7e9"
 [[buildpacks]]
-  id = "heroku/scala"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:39ad34bcc1766cdff4f2a4d5e88931a2f2678f5605bd56f1b6fc551f40fba70f"
-
+id = "heroku/scala"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:99b35329c3c5af4deaab1892a6ccfad9d0646fcb8bf6fe04c688f0429d95fc11"
 [[buildpacks]]
-  id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
-
+id = "heroku/java-function"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
 [[buildpacks]]
-  id = "heroku/ruby"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
-
+id = "heroku/ruby"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
 [[buildpacks]]
-  id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
-
+id = "heroku/procfile"
+uri = "docker://docker.io/heroku/procfile-cnb@sha256:2cb7e101c876056356c1112a827bcb857669e42c209cd472dc9dc7c1bbd3fe7d"
 [[buildpacks]]
-  id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
-
+id = "heroku/python"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
 [[buildpacks]]
-  id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
-
+id = "heroku/php"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
 [[buildpacks]]
-  id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
-
+id = "heroku/go"
+uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
 [[buildpacks]]
-  id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:b43e71d5338657097582cd48ba27fb0970ace81e08ac25dcf9bbd2659b9f8b14"
-
+id = "heroku/nodejs"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:30ab86eed55dd816fa45045dd549db97c8cfd5b9c492eae79b3095a3fafaf3a5"
 [[buildpacks]]
-  id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:68d9d869c9c0ea8dd964bfdabe3330a5da09fdab8be56142f10494ee5ab0e31c"
-
+id = "heroku/nodejs-function"
+uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:68d9d869c9c0ea8dd964bfdabe3330a5da09fdab8be56142f10494ee5ab0e31c"
 [[order]]
-  [[order.group]]
-    id = "heroku/ruby"
-    version = "0.1.3"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/ruby"
+version = "0.1.3"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/python"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/python"
+version = "0.3.1"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/scala"
-    version = "0.0.90"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/scala"
+version = "0.0.91"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/php"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/php"
+version = "0.3.1"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/go"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "0.6.2"
-    optional = true
-
+[[order.group]]
+id = "heroku/go"
+version = "0.3.1"
+[[order.group]]
+id = "heroku/procfile"
+optional = true
+version = "0.7.1"
 [[order]]
-  [[order.group]]
-    id = "heroku/nodejs-function"
-    version = "0.6.8"
-
+[[order.group]]
+id = "heroku/nodejs-function"
+version = "0.6.8"
 [[order]]
-  [[order.group]]
-    id = "heroku/java-function"
-    version = "0.3.24"
-
+[[order.group]]
+id = "heroku/java-function"
+version = "0.3.24"
 [[order]]
-  [[order.group]]
-    id = "heroku/nodejs"
-    version = "0.3.6"
-
+[[order.group]]
+id = "heroku/nodejs"
+version = "0.3.8"
 [[order]]
-  [[order.group]]
-    id = "heroku/java"
-    version = "0.3.13"
+[[order.group]]
+id = "heroku/java"
+version = "0.3.13"


### PR DESCRIPTION
Spike on automating pack-image file updates
The problem I'm addressing is somewhat described in https://salesforce.quip.com/J3ZpAihiOAaZ. Currently, deploying to `pack-images` is manual. Developers must deploy the changes and then manually update the builder files.

As seen in https://github.com/heroku/pack-images/pull/212, the dev must remember to edit two files and two separate locations (with the same info).

This PR spikes out automating updating the files, which could be extended out to automate the entire deploy via a GitHub action eventually.

## Difficult to get right

To prove my point that it's difficult and error-prone to update these files manually when I ran the script, it showed that:

- heroku/procfile buildpack is wildly out of date
- heroku/scala is out of date
- heroku/nodejs is out of date

(See changes in builder-18.toml, and builder-20.toml files)

## Automation

This change works by reading in the existing files, querying the "registry" (just a GitHub repo) https://github.com/buildpacks/registry-index, and then updating the URI and version numbers on disk to match the last non-yanked registry entry for that buildpack.

## Use instructions

```
$ bundle exec rake fetch:latest
```

## Concerns

- Machine versus human toml

The `TomlRB` gem currently does not "pretty" print or format the toml output in any way. That means our indentation and logical newlines will be different between humans and machines updating this file.

While it's jarring for now, if mostly machines update this file, humans will eventually not care about the formatting.

If it's a huge concern, we could upstream a "pretty print" mode to the toml-rb gem, but that may be a significant effort.

- All latest all the time

This code assumes we want the latest versions always. Since the script still needs to be manually executed and the developer still needs to commit and make a PR. The PR must be approved...there's still an opportunity to manually point at older versions, but it won't be the default.

- Doesn't handle shimmed buildpacks

Currently, the PHP, Python, and GO buildpacks use a shim instead of the registry. I have to skip them manually.

## Definition of Done

For a definition of done, I need feedback on the above concerns.

- Add unit tests
- Port logic out of the Rake task and towards testable classes
- Update the README and docs to reflect the new workflow
- Handle shimmed buildpacks
- Take this as an opportunity to talk about how we would get this running on GitHub-actions along with signed commits



GUS-W-10100382