### PR TITLE
Use `heroku/buildpacks:20` as `heroku/buildpacks:latest`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,8 +380,7 @@ workflows:
           name: publish-service-builder-18
           image_file: buildpacks-18.tar
           image_tag: heroku/buildpacks:18
-          image_tag_alias: heroku/buildpacks:latest
-          image_tag_alias2: $REGISTRY_HOST/s/heroku/cnb/heroku-18:builder
+          image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-18:builder
           requires:
             - publish-18-build-stack
             - publish-18-run-stack
@@ -429,6 +428,7 @@ workflows:
           image_file: buildpacks-20.tar
           image_tag: heroku/buildpacks:20
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-20:builder
+          image_tag_alias2: heroku/buildpacks:latest
           requires:
             - publish-20-build-stack
             - publish-20-run-stack

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20 -t heroku/pack:20 .
 	@pack create-builder heroku/buildpacks:18 --config builder-18.toml --pull-policy if-not-present
 	@pack create-builder heroku/buildpacks:20 --config builder-20.toml --pull-policy if-not-present
-	@docker tag heroku/buildpacks:18 heroku/buildpacks:latest
+	@docker tag heroku/buildpacks:20 heroku/buildpacks:latest
 
 publish: build
 	@docker push heroku/pack:18-build


### PR DESCRIPTION
Makes `heroku/buildpacks:latest` be tagged from `heroku/buildpacks:20` rather than `heroku/buildpacks:18`, since the default and latest stack is Heroku-20.

This is a no-op for Kodon, since it pins to a specific builder tag, rather than latest.