### PR TITLE
Bump nodejs-function to 0.6.10

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -46,7 +46,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:68d9d869c9c0ea8dd964bfdabe3330a5da09fdab8be56142f10494ee5ab0e31c"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:cdd5f5c2f577edcb4816b2e20c0785646998e013984684a1c341944225917a03"
 
 [[order]]
   [[order.group]]

--- a/builder-18.toml
+++ b/builder-18.toml
@@ -101,7 +101,7 @@ version = "0.13.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.6.8"
+    version = "0.6.10"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -46,7 +46,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:68d9d869c9c0ea8dd964bfdabe3330a5da09fdab8be56142f10494ee5ab0e31c"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:cdd5f5c2f577edcb4816b2e20c0785646998e013984684a1c341944225917a03"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -101,7 +101,7 @@ version = "0.13.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.6.8"
+    version = "0.6.10"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This bumps the nodejs-function buildpack to the latest release. There are only minor changes described here: https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/266.

GUS-W-10379120