### PR TITLE
Update heroku/java-function to 0.3.25

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -18,7 +18,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:828b0f7d74a3cf831afd5d3bb1c238a6968fd49fb9c4af73fbe19bd3383fb7b3"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.13.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.24"
+    version = "0.3.25"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -18,7 +18,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f506598a47ee80c1eba98345fb49be66745dcb3e6d01a9f1b98a93e095c84ddd"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:828b0f7d74a3cf831afd5d3bb1c238a6968fd49fb9c4af73fbe19bd3383fb7b3"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.13.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.24"
+    version = "0.3.25"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
## `heroku/java-function` `0.3.25`
* Upgraded `heroku/jvm-function-invoker` to `0.6.1`

## `heroku/jvm-function-invoker` `0.6.1`
* Switch to BSD 3-Clause License
* Upgrade to `libcnb` version `0.4.0`
* Updated function runtime to `1.0.5`
