### PR TITLE
Update heroku/scala to 0.0.92

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -14,7 +14,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/scala"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:39ad34bcc1766cdff4f2a4d5e88931a2f2678f5605bd56f1b6fc551f40fba70f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:02a26d364465a567782806effa2afbf4b992a1e15453bb8e62c5da27118dc7e6"
 
 [[buildpacks]]
   id = "heroku/java-function"
@@ -71,7 +71,7 @@ version = "0.13.1"
 [[order]]
   [[order.group]]
     id = "heroku/scala"
-    version = "0.0.90"
+    version = "0.0.92"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -14,7 +14,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/scala"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:39ad34bcc1766cdff4f2a4d5e88931a2f2678f5605bd56f1b6fc551f40fba70f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:02a26d364465a567782806effa2afbf4b992a1e15453bb8e62c5da27118dc7e6"
 
 [[buildpacks]]
   id = "heroku/java-function"
@@ -71,7 +71,7 @@ version = "0.13.1"
 [[order]]
   [[order.group]]
     id = "heroku/scala"
-    version = "0.0.90"
+    version = "0.0.92"
 
   [[order.group]]
     id = "heroku/procfile"


### PR DESCRIPTION
## `heroku/scala` `0.0.92`

This release is based on a classic Heroku buildpack via [cnb-shim](https://github.com/heroku/cnb-shim). The changelog for that release can be found here: https://github.com/heroku/heroku-buildpack-scala/blob/main/CHANGELOG.md#v92

Switch to BSD 3-Clause License