### PR TITLE
Add heroku:22 images and automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,12 +352,6 @@ workflows:
           name: test-ruby-20
           requires:
             - create-service-builder-20
-      - test-getting-started-guide:
-          language: Ruby
-          stack-tag: "20"
-          name: test-ruby-22
-          requires:
-            - create-service-builder-22
       - test-example:
           name: test-java-function-example-18
           example: javafunctionscaffold
@@ -517,7 +511,6 @@ workflows:
             - test-node-js-22
             - test-php-22
             - test-python-22
-            - test-ruby-22
             - test-typescript-22
           filters:
             branches:
@@ -534,7 +527,6 @@ workflows:
             - test-node-js-22
             - test-php-22
             - test-python-22
-            - test-ruby-22
             - test-typescript-22
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,14 +83,14 @@ jobs:
       stack-tag:
         description: "The tag of the run stack (ex. '20' for heroku/heroku:20)"
         type: string
-    docker:
-      - image: cimg/base:stable-20.04
+    machine:
+      image: ubuntu-2004:current
+    resource_class: large
     steps:
       - run: git clone https://github.com/heroku/<< parameters.language >>-getting-started.git getting_started
       - run: *create-docker-config
       - pack/install-pack:
           version: 0.24.1
-      - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-build.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,7 +512,6 @@ workflows:
           image_file: buildpacks-22.tar
           image_tag: heroku/buildpacks:22
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-22:builder
-          image_tag_alias2: heroku/buildpacks:latest
           requires:
             - publish-22-build-stack
             - publish-22-run-stack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,12 +317,6 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
-          language: php
-          stack-tag: "22"
-          name: test-php-22
-          requires:
-            - create-service-builder-22
-      - test-getting-started-guide:
           language: Python
           stack-tag: "18"
           name: test-python-18
@@ -334,12 +328,6 @@ workflows:
           name: test-python-20
           requires:
             - create-service-builder-20
-      - test-getting-started-guide:
-          language: Python
-          stack-tag: "22"
-          name: test-python-22
-          requires:
-            - create-service-builder-22
       - test-getting-started-guide:
           language: Ruby
           stack-tag: "18"
@@ -507,10 +495,7 @@ workflows:
           requires:
             - test-javascript-function-example-22
             - test-typescript-function-example-22
-            - test-go-22
             - test-node-js-22
-            - test-php-22
-            - test-python-22
             - test-typescript-22
           filters:
             branches:
@@ -523,10 +508,7 @@ workflows:
           requires:
             - test-javascript-function-example-22
             - test-typescript-function-example-22
-            - test-go-22
             - test-node-js-22
-            - test-php-22
-            - test-python-22
             - test-typescript-22
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,12 +251,6 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
-          language: go
-          stack-tag: "22"
-          name: test-go-22
-          requires:
-            - create-service-builder-22
-      - test-getting-started-guide:
           language: java
           stack-tag: "18"
           name: test-java-18

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,14 +109,14 @@ jobs:
       stack-tag:
         description: "The tag of the run stack (ex. '20' for heroku/heroku:20)"
         type: string
-    docker:
-      - image: cimg/base:stable-20.04
+    machine:
+      image: ubuntu-2004:current
+    resource_class: large
     steps:
       - checkout
       - run: *create-docker-config
       - pack/install-pack:
           version: 0.24.1
-      - setup_remote_docker
       - attach_workspace:
           at: /tmp/workspace
       - run: docker load < /tmp/workspace/pack-<< parameters.stack-tag >>-build.tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,12 +269,6 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
-          language: java
-          stack-tag: "22"
-          name: test-java-22
-          requires:
-            - create-service-builder-22
-      - test-getting-started-guide:
           language: node-js
           stack-tag: "18"
           name: test-node-js-18
@@ -376,12 +370,6 @@ workflows:
           stack-tag: "20"
           requires:
             - create-service-builder-20
-      - test-example:
-          name: test-java-function-example-22
-          example: javafunctionscaffold
-          stack-tag: "22"
-          requires:
-            - create-service-builder-22
       - test-example:
           name: test-javascript-function-example-18
           example: javascriptfunctionscaffold
@@ -523,11 +511,9 @@ workflows:
           image_tag: heroku/pack:22-build
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-22:build
           requires:
-            - test-java-function-example-22
             - test-javascript-function-example-22
             - test-typescript-function-example-22
             - test-go-22
-            - test-java-22
             - test-node-js-22
             - test-php-22
             - test-python-22
@@ -542,11 +528,9 @@ workflows:
           image_tag: heroku/pack:22
           image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-22:run
           requires:
-            - test-java-function-example-22
             - test-javascript-function-example-22
             - test-typescript-function-example-22
             - test-go-22
-            - test-java-22
             - test-node-js-22
             - test-php-22
             - test-python-22

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,20 @@ workflows:
           stack_name: heroku-20
           image_tag: heroku/pack:20
           image_file: pack-20-run.tar
+      - create-image:
+          name: create-22-build-image
+          dockerfile: Dockerfile.build
+          base_image: heroku/heroku:22-build
+          stack_name: heroku-22
+          image_tag: heroku/pack:22-build
+          image_file: pack-22-build.tar
+      - create-image:
+          name: create-22-run-image
+          dockerfile: Dockerfile.run
+          base_image: heroku/heroku:22
+          stack_name: heroku-22
+          image_tag: heroku/pack:22
+          image_file: pack-22-run.tar
       - create-pack-builder:
           name: create-service-builder-18
           image_tag: heroku/buildpacks:18
@@ -216,6 +230,14 @@ workflows:
           requires:
             - create-20-run-image
             - create-20-build-image
+      - create-pack-builder:
+          name: create-service-builder-22
+          image_tag: heroku/buildpacks:22
+          image_file: buildpacks-22.tar
+          builder_toml: builder-22.toml
+          requires:
+            - create-22-run-image
+            - create-22-build-image
       - test-getting-started-guide:
           language: go
           stack-tag: "18"
@@ -229,6 +251,12 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
+          language: go
+          stack-tag: "22"
+          name: test-go-22
+          requires:
+            - create-service-builder-22
+      - test-getting-started-guide:
           language: java
           stack-tag: "18"
           name: test-java-18
@@ -240,6 +268,12 @@ workflows:
           name: test-java-20
           requires:
             - create-service-builder-20
+      - test-getting-started-guide:
+          language: java
+          stack-tag: "22"
+          name: test-java-22
+          requires:
+            - create-service-builder-22
       - test-getting-started-guide:
           language: node-js
           stack-tag: "18"
@@ -253,6 +287,12 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
+          language: node-js
+          stack-tag: "22"
+          name: test-node-js-22
+          requires:
+            - create-service-builder-22
+      - test-getting-started-guide:
           language: typescript
           stack-tag: "18"
           name: test-typescript-18
@@ -264,6 +304,12 @@ workflows:
           name: test-typescript-20
           requires:
             - create-service-builder-20
+      - test-getting-started-guide:
+          language: typescript
+          stack-tag: "22"
+          name: test-typescript-22
+          requires:
+            - create-service-builder-22
       - test-getting-started-guide:
           language: php
           stack-tag: "18"
@@ -277,6 +323,12 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
+          language: php
+          stack-tag: "22"
+          name: test-php-22
+          requires:
+            - create-service-builder-22
+      - test-getting-started-guide:
           language: Python
           stack-tag: "18"
           name: test-python-18
@@ -289,6 +341,12 @@ workflows:
           requires:
             - create-service-builder-20
       - test-getting-started-guide:
+          language: Python
+          stack-tag: "22"
+          name: test-python-22
+          requires:
+            - create-service-builder-22
+      - test-getting-started-guide:
           language: Ruby
           stack-tag: "18"
           name: test-ruby-18
@@ -300,6 +358,12 @@ workflows:
           name: test-ruby-20
           requires:
             - create-service-builder-20
+      - test-getting-started-guide:
+          language: Ruby
+          stack-tag: "20"
+          name: test-ruby-22
+          requires:
+            - create-service-builder-22
       - test-example:
           name: test-java-function-example-18
           example: javafunctionscaffold
@@ -313,6 +377,12 @@ workflows:
           requires:
             - create-service-builder-20
       - test-example:
+          name: test-java-function-example-22
+          example: javafunctionscaffold
+          stack-tag: "22"
+          requires:
+            - create-service-builder-22
+      - test-example:
           name: test-javascript-function-example-18
           example: javascriptfunctionscaffold
           stack-tag: "18"
@@ -325,6 +395,12 @@ workflows:
           requires:
             - create-service-builder-20
       - test-example:
+          name: test-javascript-function-example-22
+          example: javascriptfunctionscaffold
+          stack-tag: "22"
+          requires:
+            - create-service-builder-22
+      - test-example:
           name: test-typescript-function-example-18
           example: typescriptfunctionscaffold
           stack-tag: "18"
@@ -336,6 +412,12 @@ workflows:
           stack-tag: "20"
           requires:
             - create-service-builder-20
+      - test-example:
+          name: test-typescript-function-example-22
+          example: typescriptfunctionscaffold
+          stack-tag: "22"
+          requires:
+            - create-service-builder-22
       - publish-image:
           name: publish-18-build-stack
           image_file: pack-18-build.tar
@@ -432,6 +514,56 @@ workflows:
           requires:
             - publish-20-build-stack
             - publish-20-run-stack
+          filters:
+            branches:
+              only: master
+      - publish-image:
+          name: publish-22-build-stack
+          image_file: pack-22-build.tar
+          image_tag: heroku/pack:22-build
+          image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-22:build
+          requires:
+            - test-java-function-example-22
+            - test-javascript-function-example-22
+            - test-typescript-function-example-22
+            - test-go-22
+            - test-java-22
+            - test-node-js-22
+            - test-php-22
+            - test-python-22
+            - test-ruby-22
+            - test-typescript-22
+          filters:
+            branches:
+              only: master
+      - publish-image:
+          name: publish-22-run-stack
+          image_file: pack-22-run.tar
+          image_tag: heroku/pack:22
+          image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-22:run
+          requires:
+            - test-java-function-example-22
+            - test-javascript-function-example-22
+            - test-typescript-function-example-22
+            - test-go-22
+            - test-java-22
+            - test-node-js-22
+            - test-php-22
+            - test-python-22
+            - test-ruby-22
+            - test-typescript-22
+          filters:
+            branches:
+              only: master
+      - publish-image:
+          name: publish-service-builder-22
+          image_file: buildpacks-22.tar
+          image_tag: heroku/buildpacks:22
+          image_tag_alias: $REGISTRY_HOST/s/heroku/cnb/heroku-22:builder
+          image_tag_alias2: heroku/buildpacks:latest
+          requires:
+            - publish-22-build-stack
+            - publish-22-run-stack
           filters:
             branches:
               only: master

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,23 @@ SHELL=/bin/bash -o pipefail
 build:
 	@docker build --pull -f Dockerfile.build --build-arg STACK=heroku-18 --build-arg BASE_IMAGE=heroku/heroku:18-build -t heroku/pack:18-build .
 	@docker build --pull -f Dockerfile.build --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20-build -t heroku/pack:20-build .
+	@docker build --pull -f Dockerfile.build --build-arg STACK=heroku-22 --build-arg BASE_IMAGE=heroku/heroku:22-build -t heroku/pack:22-build .
 	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-18 --build-arg BASE_IMAGE=heroku/heroku:18 -t heroku/pack:18 .
 	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-20 --build-arg BASE_IMAGE=heroku/heroku:20 -t heroku/pack:20 .
+	@docker build --pull -f Dockerfile.run --build-arg STACK=heroku-22 --build-arg BASE_IMAGE=heroku/heroku:22 -t heroku/pack:22 .
 	@pack create-builder heroku/buildpacks:18 --config builder-18.toml --pull-policy if-not-present
 	@pack create-builder heroku/buildpacks:20 --config builder-20.toml --pull-policy if-not-present
+	@pack create-builder heroku/buildpacks:22 --config builder-22.toml --pull-policy if-not-present
 	@docker tag heroku/buildpacks:20 heroku/buildpacks:latest
 
 publish: build
 	@docker push heroku/pack:18-build
 	@docker push heroku/pack:20-build
+	@docker push heroku/pack:22-build
 	@docker push heroku/pack:18
 	@docker push heroku/pack:20
+	@docker push heroku/pack:22
 	@docker push heroku/buildpacks:18
 	@docker push heroku/buildpacks:20
+	@docker push heroku/buildpacks:22
 	@docker push heroku/buildpacks:latest

--- a/README.md
+++ b/README.md
@@ -10,15 +10,22 @@ Heroku-like builds with [Cloud Native Buildpacks'](https://buildpacks.io)
   compatible run image based on heroku:18
 * [heroku/pack:20](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
   compatible run image based on heroku:20
+* [heroku/pack:22](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
+  compatible run image based on heroku:22
 * [heroku/pack:18-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
   compatible build image based on heroku:18-build
 * [heroku/pack:20-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
   compatible build image based on heroku:20-build
+* [heroku/pack:22-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
+  compatible build image based on heroku:22-build
 * [heroku/buildpacks:18](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
   CNB Builder that features the heroku-18 stack, heroku buildpacks, and
   Salesforce Function buildpacks
 * [heroku/buildpacks:20](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
   CNB Builder that features the heroku-20 stack, heroku buildpacks, and
+  Salesforce Function buildpacks
+* [heroku/buildpacks:22](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
+  CNB Builder that features the heroku-22 stack, heroku buildpacks, and
   Salesforce Function buildpacks
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,28 +6,18 @@ This repository is responsible for building and publishing images that enable
 Heroku-like builds with [Cloud Native Buildpacks'](https://buildpacks.io)
 [`pack`](https://github.com/buildpacks/pack) command.
 
-* [heroku/pack:18](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
-  compatible run image based on heroku:18
-* [heroku/pack:20](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
-  compatible run image based on heroku:20
-* [heroku/pack:22](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
-  compatible run image based on heroku:22
-* [heroku/pack:18-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
-  compatible build image based on heroku:18-build
-* [heroku/pack:20-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
-  compatible build image based on heroku:20-build
-* [heroku/pack:22-build](https://hub.docker.com/r/heroku/pack/tags/) - A CNB
-  compatible build image based on heroku:22-build
-* [heroku/buildpacks:18](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
-  CNB Builder that features the heroku-18 stack, heroku buildpacks, and
-  Salesforce Function buildpacks
-* [heroku/buildpacks:20](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
-  CNB Builder that features the heroku-20 stack, heroku buildpacks, and
-  Salesforce Function buildpacks
-* [heroku/buildpacks:22](https://hub.docker.com/r/heroku/buildpacks/tags/) - A
-  CNB Builder that features the heroku-22 stack, heroku buildpacks, and
-  Salesforce Function buildpacks
+| Image                                                                    | Base      | Type              | Status         |
+|--------------------------------------------------------------------------|-----------|-------------------|----------------|
+| [heroku/pack:18](https://hub.docker.com/r/heroku/pack/tags/)             | heroku:18 | CNB Run Image     | Available      |
+| [heroku/pack:18-build](https://hub.docker.com/r/heroku/pack/tags/)       | heroku:18 | CNB Build Image   | Available      |
+| [heroku/buildpacks:18](https://hub.docker.com/r/heroku/buildpacks/tags/) | heroku:18 | CNB Builder Image | Available      |
+| [heroku/pack:20](https://hub.docker.com/r/heroku/pack/tags/)             | heroku:20 | CNB Run Image     | Suggested      |
+| [heroku/pack:20-build](https://hub.docker.com/r/heroku/pack/tags/)       | heroku:20 | CNB Build Image   | Suggested      |
+| [heroku/buildpacks:20](https://hub.docker.com/r/heroku/buildpacks/tags/) | heroku:20 | CNB Builder Image | Suggested      |
+| [heroku/pack:22](https://hub.docker.com/r/heroku/pack/tags/)             | heroku:22 | CNB Run Image     | In Development |
+| [heroku/pack:22-build](https://hub.docker.com/r/heroku/pack/tags/)       | heroku:22 | CNB Build Image   | In Development |
+| [heroku/buildpacks:22](https://hub.docker.com/r/heroku/buildpacks/tags/) | heroku:22 | CNB Builder Image | In Development |
 
 ## Usage
 
-`pack build myapp --builder heroku/buildpacks:18`
+`pack build myapp --builder heroku/buildpacks:20`

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -9,10 +9,6 @@ run-image = "heroku/pack:22"
 version = "0.13.5"
 
 [[buildpacks]]
-  id = "heroku/ruby"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
-
-[[buildpacks]]
   id = "heroku/procfile"
   uri = "docker://docker.io/heroku/procfile-cnb:1.0.1"
 
@@ -35,16 +31,6 @@ version = "0.13.5"
 [[buildpacks]]
   id = "heroku/nodejs-function"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:04c06bf8b9cea7bd30423a1208e2808119d376372bf38047f6969b0f90419936"
-
-[[order]]
-  [[order.group]]
-    id = "heroku/ruby"
-    version = "0.1.3"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "1.0.1"
-    optional = true
 
 [[order]]
   [[order.group]]

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -9,18 +9,6 @@ run-image = "heroku/pack:22"
 version = "0.13.5"
 
 [[buildpacks]]
-  id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:82e235e8c4e5d6d9e0e1e3ba59d8114871565fb2b7df63bcef48d67ecacc09e6"
-
-[[buildpacks]]
-  id = "heroku/scala"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:02a26d364465a567782806effa2afbf4b992a1e15453bb8e62c5da27118dc7e6"
-
-[[buildpacks]]
-  id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:a27030592f648d5ef32fe9bcbfe326d435698a748b8fa17b1d43a23fea27ec51"
-
-[[buildpacks]]
   id = "heroku/ruby"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
 
@@ -70,16 +58,6 @@ version = "0.13.5"
 
 [[order]]
   [[order.group]]
-    id = "heroku/scala"
-    version = "0.0.92"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "1.0.0"
-    optional = true
-
-[[order]]
-  [[order.group]]
     id = "heroku/php"
     version = "0.3.1"
 
@@ -105,15 +83,5 @@ version = "0.13.5"
 
 [[order]]
   [[order.group]]
-    id = "heroku/java-function"
-    version = "0.3.29"
-
-[[order]]
-  [[order.group]]
     id = "heroku/nodejs"
     version = "0.5.1"
-
-[[order]]
-  [[order.group]]
-    id = "heroku/java"
-    version = "0.3.16"

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -14,18 +14,18 @@ version = "0.13.5"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:15c9702d44be12ec9238fefa912f504013cc0804812e49987ed4bccc6412d6d6"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c4de76730ea8d0c68ccf1c073734ae467890545eec5896fa5ae805e2883ff20d"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:04c06bf8b9cea7bd30423a1208e2808119d376372bf38047f6969b0f90419936"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:6989739efd5c866907bedf235e0e350bb53938d482377c1bf116f70752794f41"
 
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.8.1"
+    version = "0.9.1"
 
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.1"
+    version = "0.5.3"

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -14,7 +14,7 @@ version = "0.13.5"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"
+  uri = "docker://docker.io/heroku/procfile-cnb:1.0.1"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -43,7 +43,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "1.0.0"
+    version = "1.0.1"
     optional = true
 
 [[order]]
@@ -53,7 +53,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "1.0.0"
+    version = "1.0.1"
     optional = true
 
 [[order]]
@@ -63,7 +63,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "1.0.0"
+    version = "1.0.1"
     optional = true
 
 [[order]]
@@ -73,7 +73,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "1.0.0"
+    version = "1.0.1"
     optional = true
 
 [[order]]

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -26,7 +26,7 @@ version = "0.13.5"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
+  uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -55,7 +55,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -65,7 +65,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -75,7 +75,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -85,7 +85,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -95,7 +95,7 @@ version = "0.13.5"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -13,54 +13,12 @@ version = "0.13.5"
   uri = "docker://docker.io/heroku/procfile-cnb:1.0.1"
 
 [[buildpacks]]
-  id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
-
-[[buildpacks]]
-  id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
-
-[[buildpacks]]
-  id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
-
-[[buildpacks]]
   id = "heroku/nodejs"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:15c9702d44be12ec9238fefa912f504013cc0804812e49987ed4bccc6412d6d6"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:04c06bf8b9cea7bd30423a1208e2808119d376372bf38047f6969b0f90419936"
-
-[[order]]
-  [[order.group]]
-    id = "heroku/python"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "1.0.1"
-    optional = true
-
-[[order]]
-  [[order.group]]
-    id = "heroku/php"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "1.0.1"
-    optional = true
-
-[[order]]
-  [[order.group]]
-    id = "heroku/go"
-    version = "0.3.1"
-
-  [[order.group]]
-    id = "heroku/procfile"
-    version = "1.0.1"
-    optional = true
 
 [[order]]
   [[order.group]]

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -6,7 +6,7 @@ build-image = "heroku/pack:22-build"
 run-image = "heroku/pack:22"
 
 [lifecycle]
-version = "0.13.1"
+version = "0.13.5"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/builder-22.toml
+++ b/builder-22.toml
@@ -1,0 +1,119 @@
+description = "Base builder for Heroku-22 stack, based on ubuntu:22.04 base image"
+
+[stack]
+id = "heroku-22"
+build-image = "heroku/pack:22-build"
+run-image = "heroku/pack:22"
+
+[lifecycle]
+version = "0.13.1"
+
+[[buildpacks]]
+  id = "heroku/java"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:82e235e8c4e5d6d9e0e1e3ba59d8114871565fb2b7df63bcef48d67ecacc09e6"
+
+[[buildpacks]]
+  id = "heroku/scala"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-scala-buildpack@sha256:02a26d364465a567782806effa2afbf4b992a1e15453bb8e62c5da27118dc7e6"
+
+[[buildpacks]]
+  id = "heroku/java-function"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:a27030592f648d5ef32fe9bcbfe326d435698a748b8fa17b1d43a23fea27ec51"
+
+[[buildpacks]]
+  id = "heroku/ruby"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
+
+[[buildpacks]]
+  id = "heroku/procfile"
+  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
+
+[[buildpacks]]
+  id = "heroku/python"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
+
+[[buildpacks]]
+  id = "heroku/php"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
+
+[[buildpacks]]
+  id = "heroku/go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
+
+[[buildpacks]]
+  id = "heroku/nodejs"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:15c9702d44be12ec9238fefa912f504013cc0804812e49987ed4bccc6412d6d6"
+
+[[buildpacks]]
+  id = "heroku/nodejs-function"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:04c06bf8b9cea7bd30423a1208e2808119d376372bf38047f6969b0f90419936"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/ruby"
+    version = "0.1.3"
+
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "0.6.2"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/python"
+    version = "0.3.1"
+
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "0.6.2"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/scala"
+    version = "0.0.92"
+
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "0.6.2"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/php"
+    version = "0.3.1"
+
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "0.6.2"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/go"
+    version = "0.3.1"
+
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "0.6.2"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs-function"
+    version = "0.8.1"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/java-function"
+    version = "0.3.29"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "0.5.1"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/java"
+    version = "0.3.16"


### PR DESCRIPTION
This introduces  build, run, and builder images and automation based on the `heroku:22` stack image. This will make it possible to run CNB builds on the new `heroku-22` stack. 

`heroku/buildpacks:22` is in development and will start out very basic, with only buildpacks known to be working on `heroku-22` included. Other language buildpacks will be added as they gain support for `heroku-22`.

[W-10345122](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000ZZE8oYAH)