### PR TITLE
Update heroku/procfile buildpack to libcnb.rs release

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -26,7 +26,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
+  uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -55,7 +55,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -65,7 +65,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -75,7 +75,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -85,7 +85,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -95,7 +95,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -26,7 +26,7 @@ version = "0.13.1"
 
 [[buildpacks]]
   id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:0.6.2"
+  uri = "docker://docker.io/heroku/procfile-cnb:1.0.0"
 
 [[buildpacks]]
   id = "heroku/python"
@@ -55,7 +55,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -65,7 +65,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -75,7 +75,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -85,7 +85,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]
@@ -95,7 +95,7 @@ version = "0.13.1"
 
   [[order.group]]
     id = "heroku/procfile"
-    version = "0.6.2"
+    version = "1.0.0"
     optional = true
 
 [[order]]


### PR DESCRIPTION
Older `heroku/procfile` versions do not support `heroku-22`.