### PR TITLE
Update to latest node buildpacks

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -42,11 +42,11 @@ version = "0.13.5"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:15c9702d44be12ec9238fefa912f504013cc0804812e49987ed4bccc6412d6d6"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:59a86f245b6e6f8e530538e44e8459aa6b7f2541ef78cd4bcf9a90bc09e28519"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:04c06bf8b9cea7bd30423a1208e2808119d376372bf38047f6969b0f90419936"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:b7298bd863b09bd6b0006250532a92190c24638f47ad3cfd531d9b936abd137a"
 
 [[order]]
   [[order.group]]
@@ -101,7 +101,7 @@ version = "0.13.5"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.8.1"
+    version = "0.9.0"
 
 [[order]]
   [[order.group]]
@@ -111,7 +111,7 @@ version = "0.13.5"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.1"
+    version = "0.5.2"
 
 [[order]]
   [[order.group]]

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -42,11 +42,12 @@ version = "0.13.5"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:15c9702d44be12ec9238fefa912f504013cc0804812e49987ed4bccc6412d6d6"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:59a86f245b6e6f8e530538e44e8459aa6b7f2541ef78cd4bcf9a90bc09e28519"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:04c06bf8b9cea7bd30423a1208e2808119d376372bf38047f6969b0f90419936"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:b7298bd863b09bd6b0006250532a92190c24638f47ad3cfd531d9b936abd137a"
+
 
 [[order]]
   [[order.group]]
@@ -101,7 +102,7 @@ version = "0.13.5"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.8.1"
+    version = "0.9.0"
 
 [[order]]
   [[order.group]]
@@ -111,7 +112,7 @@ version = "0.13.5"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.1"
+    version = "0.5.2"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This brings in the latest node buildpacks, and the following notable changes:

- https://github.com/heroku/buildpacks-nodejs/pull/225
- https://github.com/heroku/buildpacks-nodejs/pull/224
- https://github.com/heroku/buildpacks-nodejs/pull/201

[W-10915212](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000tsBWkYAM)
[W-10934205](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000u3znWYAQ)