### PR TITLE
Update base image tag names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,22 @@ This repository is responsible for building and publishing images that enable
 Heroku-like builds with [Cloud Native Buildpacks'](https://buildpacks.io)
 [`pack`](https://github.com/buildpacks/pack) command.
 
-| Image                                                                    | Base      | Type              | Status         |
-|--------------------------------------------------------------------------|-----------|-------------------|----------------|
-| [heroku/pack:18](https://hub.docker.com/r/heroku/pack/tags/)             | heroku:18 | CNB Run Image     | Available      |
-| [heroku/pack:18-build](https://hub.docker.com/r/heroku/pack/tags/)       | heroku:18 | CNB Build Image   | Available      |
-| [heroku/buildpacks:18](https://hub.docker.com/r/heroku/buildpacks/tags/) | heroku:18 | CNB Builder Image | Available      |
-| [heroku/pack:20](https://hub.docker.com/r/heroku/pack/tags/)             | heroku:20 | CNB Run Image     | Suggested      |
-| [heroku/pack:20-build](https://hub.docker.com/r/heroku/pack/tags/)       | heroku:20 | CNB Build Image   | Suggested      |
-| [heroku/buildpacks:20](https://hub.docker.com/r/heroku/buildpacks/tags/) | heroku:20 | CNB Builder Image | Suggested      |
-| [heroku/pack:22](https://hub.docker.com/r/heroku/pack/tags/)             | heroku:22 | CNB Run Image     | In Development |
-| [heroku/pack:22-build](https://hub.docker.com/r/heroku/pack/tags/)       | heroku:22 | CNB Build Image   | In Development |
-| [heroku/buildpacks:22](https://hub.docker.com/r/heroku/buildpacks/tags/) | heroku:22 | CNB Builder Image | In Development |
+| Image                                   | Base                                   | Type              | Status         |
+|-----------------------------------------|----------------------------------------|-------------------|----------------|
+| [heroku/pack:18][pack-tags]             | [heroku/heroku:18][stack-images]       | CNB Run Image     | Available      |
+| [heroku/pack:18-build][pack-tags]       | [heroku/heroku:18-build][stack-images] | CNB Build Image   | Available      |
+| [heroku/buildpacks:18][buildpacks-tags] | [heroku/heroku:18-build][stack-images] | CNB Builder Image | Available      |
+| [heroku/pack:20][pack-tags]             | [heroku/heroku:20][stack-images]       | CNB Run Image     | Suggested      |
+| [heroku/pack:20-build][pack-tags]       | [heroku/heroku:20-build][stack-images] | CNB Build Image   | Suggested      |
+| [heroku/buildpacks:20][buildpacks-tags] | [heroku/heroku:20-build][stack-images] | CNB Builder Image | Suggested      |
+| [heroku/pack:22][pack-tags]             | [heroku/heroku:22][stack-images]       | CNB Run Image     | In Development |
+| [heroku/pack:22-build][pack-tags]       | [heroku/heroku:22-build][stack-images] | CNB Build Image   | In Development |
+| [heroku/buildpacks:22][buildpacks-tags] | [heroku/heroku:22-build][stack-images] | CNB Builder Image | In Development |
 
 ## Usage
 
 `pack build myapp --builder heroku/buildpacks:20`
+
+[pack-tags]: https://hub.docker.com/r/heroku/pack/tags
+[buildpacks-tags]: https://hub.docker.com/r/heroku/buildpacks/tags
+[stack-images]: https://github.com/heroku/stack-images


### PR DESCRIPTION
Previously the `Base` column used a notation that looked like a tag name (due to the colon), but wasn't a valid tag. 

I've also added links to the stack-images repository, so it's easier for users to report issues with the underlying image to the correct repository.