### PR TITLE
JVM Buildpack Updates Q2 2022

### DIFF
--- a/builder-18.toml
+++ b/builder-18.toml
@@ -10,7 +10,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:82e235e8c4e5d6d9e0e1e3ba59d8114871565fb2b7df63bcef48d67ecacc09e6"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:06938365d0bb9c2b9e3d54b50331161541a4666e2fdb14b4880c9ae95d07b2b7"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:a27030592f648d5ef32fe9bcbfe326d435698a748b8fa17b1d43a23fea27ec51"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:c913b5581cd8a935058f680e6de6b7d9fe66237c379dfddd24c2267c3f41c9ba"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.29"
+    version = "0.3.30"
 
 [[order]]
   [[order.group]]
@@ -116,4 +116,4 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.3.16"
+    version = "0.5.0"

--- a/builder-20.toml
+++ b/builder-20.toml
@@ -10,7 +10,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:82e235e8c4e5d6d9e0e1e3ba59d8114871565fb2b7df63bcef48d67ecacc09e6"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:06938365d0bb9c2b9e3d54b50331161541a4666e2fdb14b4880c9ae95d07b2b7"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:a27030592f648d5ef32fe9bcbfe326d435698a748b8fa17b1d43a23fea27ec51"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:c913b5581cd8a935058f680e6de6b7d9fe66237c379dfddd24c2267c3f41c9ba"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -107,7 +107,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.29"
+    version = "0.3.30"
 
 [[order]]
   [[order.group]]
@@ -117,4 +117,4 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.3.16"
+    version = "0.5.0"


### PR DESCRIPTION
## `heroku/jvm` `1.0.0`

* Re-implement buildpack using [libcnb.rs](https://github.com/Malax/libcnb.rs) ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Remove support for GPG signed OpenJDK binaries. This feature wasn't used and will be replaced by a unified solution across Heroku buildpacks. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Remove support for the `JDK_BASE_URL` environment variable. It was deprecated in Jan 2021 and was slated for removal Oct 2021. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Remove support for the `JVM_BUILDPACK_ASSETS_BASE_URL` environment variable. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Remove legacy debugging scripts: `with_jmap`, `with_jmap_and_jstack`, `with_jmap_and_jstack_java`, `with_jmap_java`, `with_jstack` and `with_jstack_java`. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Remove explicit setting of `-XX:+UseContainerSupport` as it's nowadays the default for all supported Java versions. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Fixed caching behaviour when a JDK overlay was used. Updated overlays will now be always applied to a clean version of OpenJDK. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Improved compatibility when reading Java properties files (`system.properties`). ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Support for selecting a major version when using Azul Zulu as the OpenJDK distribution. Users no longer have to pick a specific version when using Azul Zulu. To select, for example, the latest OpenJDK 11 release from Azul Zulu, use `java.runtime.version=zulu-11` in your `system.properties` file. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Add checksum validation when installing the Heroku JVM Metrics Agent. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* No longer installs `jq` and `yj` command-line tools during the buildpack bootstrap, improving overall build times. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Improved compatibility when rewriting the `DATABASE_URL` environment variable by using proper URL parsing. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Improved error messages when unexpected IO errors occur during the build. ([#272](https://github.com/heroku/buildpacks-jvm/pull/272))
* Default version for **OpenJDK 7** is now `1.7.0_342`
* Default version for **OpenJDK 8** is now `1.8.0_332`
* Default version for **OpenJDK 11** is now `11.0.15`
* Default version for **OpenJDK 13** is now `13.0.11`
* Default version for **OpenJDK 15** is now `15.0.7`
* Default version for **OpenJDK 17** is now `17.0.3`
* Default version for **OpenJDK 18** is now `18.0.1`

## `heroku/java` `0.5.0`

* Upgraded `heroku/jvm` to `1.0.0`
* Upgraded `heroku/procfile` to `1.0.1`

## `heroku/java-function` `0.3.30`

* Upgraded `heroku/jvm` to `1.0.0`