### PR TITLE
Fix broken CircleCI pushes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: docker load < /tmp/workspace/<< parameters.builder-dir >>.tar
+      - run: docker tag << parameters.builder-dir >> << parameters.image_tag >>
       - run: docker push << parameters.image_tag >>
       - when:
           condition: << parameters.image_tag_alias >>


### PR DESCRIPTION
Due to a few changes in #251 to the CircleCI job, publishing builder images is failing. We need to tag an image before we can push it.